### PR TITLE
Add method for WebDriver instance checking via WebDriverRunner

### DIFF
--- a/src/main/java/com/codeborne/selenide/WebDriverRunner.java
+++ b/src/main/java/com/codeborne/selenide/WebDriverRunner.java
@@ -119,6 +119,14 @@ public class WebDriverRunner {
   public static void closeWebDriver() {
     webdriverContainer.closeWebDriver();
   }
+  
+  /**
+   * Is instance of Selenium WebDriver exist
+   * @return true if instance of Selenium WebDriver exist
+   */
+  public static boolean isDriverExist() {
+    return webdriverContainer.isDriverExist();
+  }
 
   /**
    * Is Selenide configured to use Firefox browser

--- a/src/main/java/com/codeborne/selenide/impl/WebDriverThreadLocalContainer.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebDriverThreadLocalContainer.java
@@ -81,6 +81,20 @@ public class WebDriverThreadLocalContainer {
     return THREAD_WEB_DRIVER.containsKey(currentThread().getId());
   }
   
+  /**
+   * Is instance of Selenium WebDriver exist
+   * @return true if instance of Selenium WebDriver exist
+   */
+  public boolean isDriverExist() {
+    WebDriver webDriver = THREAD_WEB_DRIVER.get(currentThread().getId());
+    if (webDriver != null) {
+      if (isBrowserStillOpen(webDriver)) {
+        return true;
+      }
+    }	
+	return false;
+  }
+  
   public WebDriver getWebDriver() {
     WebDriver webDriver = THREAD_WEB_DRIVER.get(currentThread().getId());
     return webDriver != null ? webDriver : setWebDriver(createDriver());


### PR DESCRIPTION
Check of existance of WebDriver instance is needed for some purposes:
-  screenshot creation in my case (if WD alive screenshot will be captured from browser window, else from system via Robot framework)

Without of this check browser is 'blinking', because Selenide trying to restore closed WebDriver (WD can be unexpectable closed after some error in browser/IEDriverServer/tests and etc)