### PR TITLE
A new method (and property) for clicking on the element via JavaScript

### DIFF
--- a/src/main/java/com/codeborne/selenide/Configuration.java
+++ b/src/main/java/com/codeborne/selenide/Configuration.java
@@ -49,6 +49,15 @@ public class Configuration {
   public static boolean startMaximized = Boolean.parseBoolean(System.getProperty("selenide.start-maximized", "true"));
 
   /**
+   * ATTENTION! Automatic WebDriver waiting after click isn't working in case of using this feature.
+   * Use clicking via JavaScript instead common element clicking.
+   * This solution may be helpfull for testing in Internet Explorer.
+   *
+   * Default value: false
+   */
+  public static boolean clickViaJs = Boolean.parseBoolean(System.getProperty("selenide.click-via-js", "false"));
+
+  /**
    * Does Selenide need to take screenshots on failing tests.
    *
    * Default value: true

--- a/src/main/java/com/codeborne/selenide/impl/AbstractSelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/impl/AbstractSelenideElement.java
@@ -236,6 +236,10 @@ abstract class AbstractSelenideElement implements InvocationHandler {
       click();
       return null;
     }
+    else if ("clickViaJs".equals(method.getName())) {
+      clickViaJs();
+      return null;
+    }
     else if ("contextClick".equals(method.getName())) {
       contextClick();
       return null;
@@ -306,7 +310,11 @@ abstract class AbstractSelenideElement implements InvocationHandler {
   protected void setSelected(boolean selected) {
     WebElement element = waitForElement();
     if (element.isSelected() ^ selected) {
-      element.click();
+		if(!clickViaJs) {
+			element.click();
+		} else {
+			executeJavaScript("arguments[0].click()", element);
+		}
     }
   }
 
@@ -334,7 +342,15 @@ abstract class AbstractSelenideElement implements InvocationHandler {
   }
 
   protected void click() {
-    waitForElement().click();
+	if(!clickViaJs) {
+		waitForElement().click();
+	} else {
+		clickViaJs();
+	}
+  }
+
+  protected void clickViaJs() {
+	executeJavaScript("arguments[0].click()", waitForElement()); 
   }
 
   protected void contextClick() {
@@ -353,7 +369,11 @@ abstract class AbstractSelenideElement implements InvocationHandler {
   protected void followLink() {
     WebElement link = waitForElement();
     String href = link.getAttribute("href");
-    link.click();
+	if(!clickViaJs) {
+		link.click();
+	} else {
+		executeJavaScript("arguments[0].click()", link);
+	}
 
     // JavaScript $.click() doesn't take effect for <a href>
     if (href != null) {


### PR DESCRIPTION
In some case clicking on the element in IE may be instable. I found a lot of discussions about this situation with testing in IE in global network.

1) This new feature provide new method of clicking on the element - via JavaScript. At now we can use standart .click() or .clickViaJs() (for our purposes).
2) If we want to migrate all .click() in our code - we can just use "selenide.click-via-js=true" property (default is false) for some projects with testing in IE.