### PR TITLE
Cookies are not sent in FileDownloader after httpclient update

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/FileDownloader.java
+++ b/src/main/java/com/codeborne/selenide/impl/FileDownloader.java
@@ -146,6 +146,7 @@ public class FileDownloader {
   protected BasicClientCookie duplicateCookie(Cookie seleniumCookie) {
     BasicClientCookie duplicateCookie = new BasicClientCookie(seleniumCookie.getName(), seleniumCookie.getValue());
     duplicateCookie.setDomain(seleniumCookie.getDomain());
+    duplicateCookie.setAttribute(BasicClientCookie.DOMAIN_ATTR, seleniumCookie.getDomain());
     duplicateCookie.setSecure(seleniumCookie.isSecure());
     duplicateCookie.setExpiryDate(seleniumCookie.getExpiry());
     duplicateCookie.setPath(seleniumCookie.getPath());


### PR DESCRIPTION
Domain handling for cookies is changed in new version of httpclient used as dependency in Selenium.
It's necessary to set 'domain' attribute now, otherwise cookie will not sent to server. 
You can find more in https://issues.apache.org/jira/browse/HTTPCLIENT-1614