### PR TITLE
Add updateHash method (for ajax apps)

### DIFF
--- a/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/src/main/java/com/codeborne/selenide/Selenide.java
@@ -58,6 +58,17 @@ public class Selenide {
     navigator.open(absoluteUrl);
     mockModalDialogs();
   }
+  
+  /**
+   * Update the hash of the window location (usefull to navigate in ajax apps, since open(url) makes a full page reload).
+   * @param hash value for window.location.hash
+   */
+  public static void updateHash(String hash) {
+    if (hash.startsWith("#")) {
+        throw new IllegalArgumentException("hash should not start with #");
+    }
+    executeJavaScript("window.location.hash='" + hash + "'");
+  }
 
   private static boolean doDismissModalDialogs() {
     return !supportsModalDialogs() || dismissModalDialogs;


### PR DESCRIPTION
Hello.
We start using Selenide to test GWT apps, and it is very pleasant !

Here is a proposition of a method to ease navigation in ajax applications like GWT, since 
open( "#GwtPlace1:");
open( "#GwtPlace2:"); => makes a full page reload

Inspired by a solution proposed here : https://code.google.com/p/selenium/issues/detail?id=5165

updateHash("GwtPlace2:"); would just navigate to the new Place, without reloading the whole page from the server.