### PR TITLE
Implement #196 Add file downloading mechanism without "href"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ dependencies {
   provided group: 'com.codeborne', name: 'phantomjsdriver', version: '1.2.1', transitive: false
   
   // For BrowserMob Proxy:
-  testCompile group: 'net.lightbody.bmp', name: 'browsermob-proxy', version: '2.0.0', transitive: false
+  compile group: 'net.lightbody.bmp', name: 'browsermob-core-littleproxy', version: '2.1.0-beta-4'
   testRuntime group: 'org.slf4j', name: 'slf4j-jdk14', version: '1.7.13'
   testRuntime group: 'net.sf.uadetector', name: 'uadetector-resources', version: '2014.10'
   testRuntime 'com.fasterxml.jackson.core:jackson-databind:2.6.4'

--- a/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/src/main/java/com/codeborne/selenide/Selenide.java
@@ -12,6 +12,7 @@ import org.openqa.selenium.support.ui.FluentWait;
 
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.logging.Level;
@@ -58,6 +59,14 @@ public class Selenide {
   public static void open(URL absoluteUrl) {
     navigator.open(absoluteUrl);
     mockModalDialogs();
+  }
+
+  /**
+   * @see SelenideElement#prepareDownload(String, String, String...)
+   */
+  public static void prepareDownload(String toFolder, String fileName, String ... expectedContentTypes) {
+    FileDownloader.instance
+                  .prepareDownloadViaBrowserMob(toFolder, fileName, Arrays.asList(expectedContentTypes));
   }
   
   /**

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -438,6 +438,19 @@ public interface SelenideElement extends WebElement, FindsByLinkText, FindsById,
   File download() throws FileNotFoundException;
 
   /**
+   * Prepare BrowserMobProxy for catch file (via Content-Type) from next http responses.<br/>
+   * When response with selected Content-Type will be received you will see page with full path to downloaded file.<br/>
+   * Then you can use: $(By.tagName("body")).getText();<br/>
+   * For manual clearing of filters: WebDriverRunner.getBrowserMobProxy().getFilterFactories().clear();
+   * @param toFolder downloads folder absolute path
+   * @param fileName name for output file. Can be empty (name from response will be used).
+   * @param expectedContentTypes array with content types like application/pdf and etc
+   * @throws IllegalStateException if BrowserMobProxy server is null or stopped for current thread
+   * @throws IllegalArgumentException if toFolder or expectedContentTypes are empty
+   */
+  SelenideElement prepareDownload(String toFolder, String fileName, String ... expectedContentTypes);
+
+  /**
    * @return the original Selenium WebElement wrapped by this object
    */
   WebElement toWebElement();

--- a/src/main/java/com/codeborne/selenide/WebDriverRunner.java
+++ b/src/main/java/com/codeborne/selenide/WebDriverRunner.java
@@ -2,6 +2,7 @@ package com.codeborne.selenide;
 
 import com.codeborne.selenide.impl.WebDriverContainer;
 import com.codeborne.selenide.impl.WebDriverThreadLocalContainer;
+import net.lightbody.bmp.BrowserMobProxyServer;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.events.WebDriverEventListener;
@@ -50,6 +51,13 @@ public class WebDriverRunner {
    * &lt;dependency org="com.opera" name="operadriver" rev="1.5" conf="test-&gt;default"/&gt;
    */
   public static final String OPERA = "opera";
+
+  /**
+   * Browser Mob Proxy will be created within driver or not
+   * <p/>
+   * Default value: false
+   */
+  public static boolean isBrowserMobActive = false;
 
   /**
    * Use this method BEFORE opening a browser to add custom event listeners to webdriver.
@@ -102,16 +110,34 @@ public class WebDriverRunner {
     return webdriverContainer.getWebDriver();
   }
 
+
+  /**
+   * Activating Browser Mob Proxy for file downloading<br/>
+   * This method must be called BEFORE creating of WebDriver instance
+   *
+   */
+  public static void setProxyBrowserMob(boolean active) {
+    isBrowserMobActive = active;
+  }
+
+
   public static void setProxy(Proxy webProxy) {
     webdriverContainer.setProxy(webProxy);
   }
-  
+
   /**
    * Get the underlying instance of Selenium WebDriver, and assert that it's still alive.
    * @return new instance of WebDriver if the previous one has been closed meanwhile.
    */
   public static WebDriver getAndCheckWebDriver() {
     return webdriverContainer.getAndCheckWebDriver();
+  }
+
+  /**
+   * @return BrowserMob Proxy instance for current thread. Can be NULL !
+   */
+  public static BrowserMobProxyServer getBrowserMobProxy() {
+    return webdriverContainer.getBrowserMobProxy();
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/commands/Commands.java
+++ b/src/main/java/com/codeborne/selenide/commands/Commands.java
@@ -102,6 +102,7 @@ public class Commands {
 
   private void addFileCommands() {
     commands.put("download", new DownloadFile());
+    commands.put("prepareDownload", new PrepareDownload());
     commands.put("uploadFile", new UploadFile());
     commands.put("uploadFromClasspath", new UploadFileFromClasspath());
   }

--- a/src/main/java/com/codeborne/selenide/commands/PrepareDownload.java
+++ b/src/main/java/com/codeborne/selenide/commands/PrepareDownload.java
@@ -10,11 +10,12 @@ import java.util.Arrays;
 public class PrepareDownload implements Command<SelenideElement> {
   @Override
   public SelenideElement execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
-    String[] params = Arrays.copyOf(args, args.length, String[].class);
+    String[] types = (String[]) args[2];
+
     FileDownloader.instance
-                  .prepareDownloadViaBrowserMob(params[0],
-                                                params[1],
-                                                Arrays.asList(params).subList(2, params.length - 1));
+                  .prepareDownloadViaBrowserMob((String) args[0],
+                                                (String) args[1],
+                                                Arrays.asList(types));
 
     return proxy;
   }

--- a/src/main/java/com/codeborne/selenide/commands/PrepareDownload.java
+++ b/src/main/java/com/codeborne/selenide/commands/PrepareDownload.java
@@ -1,0 +1,21 @@
+package com.codeborne.selenide.commands;
+
+import com.codeborne.selenide.Command;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.FileDownloader;
+import com.codeborne.selenide.impl.WebElementSource;
+
+import java.util.Arrays;
+
+public class PrepareDownload implements Command<SelenideElement> {
+  @Override
+  public SelenideElement execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
+    String[] params = Arrays.copyOf(args, args.length, String[].class);
+    FileDownloader.instance
+                  .prepareDownloadViaBrowserMob(params[0],
+                                                params[1],
+                                                Arrays.asList(params).subList(2, params.length - 1));
+
+    return proxy;
+  }
+}

--- a/src/main/java/com/codeborne/selenide/impl/FileDownloader.java
+++ b/src/main/java/com/codeborne/selenide/impl/FileDownloader.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.cert.X509Certificate;
+import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -46,7 +47,7 @@ public class FileDownloader {
   public static FileDownloader instance = new FileDownloader();
 
   public static boolean ignoreSelfSignedCerts = true;
-  
+
   public File download(WebElement element) throws IOException {
     String fileToDownloadLocation = element.getAttribute("href");
     if (fileToDownloadLocation == null || fileToDownloadLocation.trim().isEmpty()) {
@@ -67,6 +68,26 @@ public class FileDownloader {
     }
 
     return saveFileContent(response, downloadedFile);
+  }
+
+  public void prepareDownloadViaBrowserMob(String toFolder, String fileName, List<String> contentTypes)
+          throws IllegalArgumentException, IllegalStateException  {
+    if (WebDriverRunner.getBrowserMobProxy() == null || WebDriverRunner.getBrowserMobProxy().isStopped()) {
+      throw new IllegalStateException("BrowserMob Proxy is not exist or stopped");
+    }
+    if (toFolder.isEmpty()) {
+      throw new IllegalArgumentException("Downloads folder path can not be empty");
+    }
+    if (contentTypes.isEmpty()) {
+      throw new IllegalArgumentException("Content types list can not be empty");
+    }
+
+    ResponseFilterImpl filter = new ResponseFilterImpl(toFolder)
+            .withFileName(fileName)
+            .withContentTypes(contentTypes);
+
+    WebDriverRunner.getBrowserMobProxy().getFilterFactories().clear();
+    WebDriverRunner.getBrowserMobProxy().addResponseFilter(filter);
   }
 
   protected HttpResponse executeHttpRequest(String fileToDownloadLocation) throws IOException {

--- a/src/main/java/com/codeborne/selenide/impl/ResponseFilterImpl.java
+++ b/src/main/java/com/codeborne/selenide/impl/ResponseFilterImpl.java
@@ -1,0 +1,111 @@
+package com.codeborne.selenide.impl;
+
+import io.netty.handler.codec.http.HttpResponse;
+import net.lightbody.bmp.filters.ResponseFilter;
+import net.lightbody.bmp.util.HttpMessageContents;
+import net.lightbody.bmp.util.HttpMessageInfo;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.*;
+
+
+public class ResponseFilterImpl implements ResponseFilter {
+
+  private Set<String> contentTypes = new HashSet<>(1);
+  private File tempDir;
+  private File tempFile;
+  private String outputTextContent;
+  private String fileName;
+
+
+  public ResponseFilterImpl(String pathToFolder)  {
+    tempDir = new File(pathToFolder);
+  }
+
+
+  public ResponseFilterImpl withContentTypes(String ... contentTypes) {
+    this.contentTypes.addAll(Arrays.asList(contentTypes));
+    return this;
+  }
+
+  public ResponseFilterImpl withContentTypes(List<String> contentTypes) {
+    this.contentTypes.addAll(contentTypes);
+    return this;
+  }
+
+
+  public ResponseFilterImpl withFileName(String fileName) {
+    this.fileName = fileName;
+    return this;
+  }
+
+
+  @Override
+  public void filterResponse(HttpResponse response, HttpMessageContents contents, HttpMessageInfo messageInfo) {
+    String contentType = response.headers().get("Content-Type");
+    if (contentTypes.contains(contentType)) {
+      try {
+        String actualFileName = getFileName(messageInfo.getUrl(), response);
+        if (fileName.isEmpty() && !actualFileName.isEmpty()) fileName = actualFileName;
+
+        String postfix = contentType.substring(contentType.indexOf('/') + 1);
+        if (fileName.isEmpty()) {
+          tempFile = File.createTempFile("downloaded", "." + postfix, tempDir);
+          tempFile.deleteOnExit();
+        }
+        else {
+          tempFile =  new File(tempDir.getAbsolutePath() + "/" + fileName);
+        }
+
+        outputTextContent = tempFile.getAbsolutePath();
+
+        try (FileOutputStream outputStream = new FileOutputStream(tempFile)) {
+          outputStream.write(contents.getBinaryContents());
+        }
+        catch (Throwable ex) {
+          outputTextContent = ex.getMessage();
+        }
+
+        response.headers().remove("Content-Type");
+        response.headers().remove("Content-Encoding");
+        response.headers().remove("Content-Disposition");
+
+        response.headers().add("Content-Type", "text/html");
+        response.headers().add("Content-Length", "" + outputTextContent.length());
+        contents.setTextContents(outputTextContent);
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+
+  protected String getFileName(String requestUrl, HttpResponse response)  {
+    for (Map.Entry<String, String> header : response.headers().entries()) {
+      String fileName = FileDownloader.instance
+                                      .getFileNameFromContentDisposition(header.getKey(), header.getValue());
+      if (fileName != null) {
+        return fileName;
+      }
+    }
+
+    String ret = "";
+    if (requestUrl.indexOf("\\") > requestUrl.indexOf("/")) {
+      ret = StringUtils.substringAfterLast(requestUrl, "\\");
+    } else  {
+      ret = StringUtils.substringAfterLast(requestUrl, "/");
+    }
+
+    if (ret.indexOf("?") > -1
+            && (ret.indexOf("?") < ret.indexOf("&") || ret.indexOf("&") < 0)) {
+      ret = StringUtils.substringBefore(ret, "?");
+    } else if (ret.indexOf("&") > -1) {
+      ret = StringUtils.substringBefore(ret, "&");
+    }
+
+    return ret;
+  }
+}

--- a/src/main/java/com/codeborne/selenide/impl/WebDriverContainer.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebDriverContainer.java
@@ -1,5 +1,6 @@
 package com.codeborne.selenide.impl;
 
+import net.lightbody.bmp.BrowserMobProxyServer;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.events.WebDriverEventListener;
@@ -8,6 +9,7 @@ public interface WebDriverContainer {
   void addListener(WebDriverEventListener listener);
   WebDriver setWebDriver(WebDriver webDriver);
   WebDriver getWebDriver();
+  BrowserMobProxyServer getBrowserMobProxy();
   void setProxy(Proxy webProxy);
   WebDriver getAndCheckWebDriver();
   void closeWebDriver();


### PR DESCRIPTION
@asolntsev please review first version of implementation #196 issue.

How to use in end-user projects:
```java
        Selenide.prepareDownload("C:\\SomeFolder", "", "application/x-sdlc");
        WebDriverRunner.getWebDriver().get("http://javadl.sun.com/webapps/download/AutoDL?BundleId=113227");
        // Downloaded file with name chromeinstall-8u66.exe
        File tmp = new File(Selenide.$(By.tagName("body")).getText());
```
or
```java
        Selenide.prepareDownload("C:\\SomeFolder","SomeFile.exe","application/x-sdlc");
        WebDriverRunner.getWebDriver().get("http://javadl.sun.com/webapps/download/AutoDL?BundleId=113227");
        // Downloaded file with name SomeFile.exe
        File tmp = new File(Selenide.$(By.tagName("body")).getText());
```
or
```java
        Selenide.$(By.id("button_for_file_download_after_click"))
                .prepareDownload("C:\\SomeFolder", "", "application/pdf")
                .click();
        File tmp = new File(Selenide.$(By.tagName("body")).getText());
```

TODO:
1) Review
2) Some tests
3) Merge conflicts