### PR TITLE
Comparison operator with an expected size for collections

### DIFF
--- a/src/main/java/com/codeborne/selenide/CollectionCondition.java
+++ b/src/main/java/com/codeborne/selenide/CollectionCondition.java
@@ -2,6 +2,7 @@ package com.codeborne.selenide;
 
 import com.codeborne.selenide.collections.ExactTexts;
 import com.codeborne.selenide.collections.ListSize;
+import com.codeborne.selenide.collections.ListSize.Operator;
 import com.codeborne.selenide.collections.Texts;
 import com.codeborne.selenide.impl.WebElementsCollection;
 import com.google.common.base.Predicate;
@@ -16,6 +17,10 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
 
   public static CollectionCondition size(final int expectedSize) {
     return new ListSize(expectedSize);
+  }
+
+  public static CollectionCondition size(final Operator operator, final int expectedSize) {
+    return new ListSize(operator, expectedSize);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/ElementsCollection.java
+++ b/src/main/java/com/codeborne/selenide/ElementsCollection.java
@@ -1,5 +1,6 @@
 package com.codeborne.selenide;
 
+import com.codeborne.selenide.collections.ListSize.Operator;
 import com.codeborne.selenide.ex.UIAssertionError;
 import com.codeborne.selenide.impl.*;
 import com.codeborne.selenide.logevents.SelenideLog;
@@ -28,6 +29,10 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
     return shouldHave(CollectionCondition.size(expectedSize));
   }
 
+  public ElementsCollection shouldHaveSize(Operator operator, int expectedSize) {
+    return shouldHave(CollectionCondition.size(operator, expectedSize));
+  }
+
   /**
    * $$(".error").shouldBe(empty)
    */
@@ -42,7 +47,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
   public ElementsCollection shouldHave(CollectionCondition... conditions) {
     return should("have", conditions);
   }
-  
+
   protected ElementsCollection should(String prefix, CollectionCondition... conditions) {
     SelenideLog log = SelenideLogger.beginStep(collection.description(), "should " + prefix, conditions);
     try {
@@ -176,7 +181,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
   public SelenideElement first() {
     return get(0);
   }
-  
+
   public SelenideElement last() {
     return get(size() - 1);
   }

--- a/src/main/java/com/codeborne/selenide/collections/ListSize.java
+++ b/src/main/java/com/codeborne/selenide/collections/ListSize.java
@@ -9,23 +9,74 @@ import java.util.List;
 
 public class ListSize extends CollectionCondition {
   protected final int expectedSize;
+  protected final Operator operator;
 
   public ListSize(int expectedSize) {
     this.expectedSize = expectedSize;
+    this.operator = Operator.EQUALS;
+  }
+
+  public ListSize(Operator operator, int expectedSize) {
+    this.expectedSize = expectedSize;
+    this.operator = operator;
   }
 
   @Override
   public boolean apply(List<WebElement> elements) {
-    return elements.size() == expectedSize;
+    switch (this.operator) {
+      case EQUALS: return elements.size() == expectedSize;
+      case GREATER_OR_EQUALS: return elements.size() >= expectedSize;
+      case GREATER: return elements.size() > expectedSize;
+      case LESS_OR_EQUALS: return elements.size() <= expectedSize;
+      case LESS: return elements.size() < expectedSize;
+      case NOT_EQUAL: return elements.size() != expectedSize;
+      default: return elements.size() == expectedSize;
+    }
   }
 
   @Override
   public void fail(WebElementsCollection collection, List<WebElement> elements, Exception lastError, long timeoutMs) {
-    throw new ListSizeMismatch(expectedSize, collection, elements, lastError, timeoutMs);
+    throw new ListSizeMismatch(operator, expectedSize, collection, elements, lastError, timeoutMs);
   }
 
   @Override
   public String toString() {
     return String.format("size(%s)", expectedSize);
+  }
+
+  /**
+   * Comparison operators for size of collections.
+   */
+  public enum Operator {
+    /**
+     * Math sign: =
+     */
+    EQUALS("="),
+    /**
+     * Math sign: >=
+     */
+    GREATER_OR_EQUALS(">="),
+    /**
+     * Math sign: >
+     */
+    GREATER(">"),
+    /**
+     * Math sign: <=
+     */
+    LESS_OR_EQUALS("<="),
+    /**
+     * Math sign: <
+     */
+    LESS("<"),
+    /**
+     * Math sign: !=
+     */
+    NOT_EQUAL("!=");
+
+    public final String sign;
+
+    Operator(String sign){
+      this.sign = sign;
+    }
   }
 }

--- a/src/main/java/com/codeborne/selenide/ex/ListSizeMismatch.java
+++ b/src/main/java/com/codeborne/selenide/ex/ListSizeMismatch.java
@@ -1,5 +1,6 @@
 package com.codeborne.selenide.ex;
 
+import com.codeborne.selenide.collections.ListSize.Operator;
 import com.codeborne.selenide.impl.WebElementsCollection;
 import org.openqa.selenium.WebElement;
 
@@ -8,9 +9,10 @@ import java.util.List;
 import static com.codeborne.selenide.ElementsCollection.elementsToString;
 
 public class ListSizeMismatch extends UIAssertionError {
-  public ListSizeMismatch(int expectedSize, WebElementsCollection collection, List<WebElement> actualElements,
+  public ListSizeMismatch(Operator operator, int expectedSize,
+                          WebElementsCollection collection, List<WebElement> actualElements,
                           Exception lastError, long timeoutMs) {
-    super(": expected: " + expectedSize +
+    super(": expected: " + operator.sign + " " + expectedSize +
         ", actual: " + (actualElements == null ? 0 : actualElements.size()) +
         ", collection: " + collection.description() +
         "\nElements: " + elementsToString(actualElements), lastError

--- a/src/test/java/integration/CollectionMethodsTest.java
+++ b/src/test/java/integration/CollectionMethodsTest.java
@@ -13,6 +13,7 @@ import static com.codeborne.selenide.CollectionCondition.*;
 import static com.codeborne.selenide.Condition.*;
 import static com.codeborne.selenide.Selectors.byText;
 import static com.codeborne.selenide.Selenide.*;
+import static com.codeborne.selenide.collections.ListSize.Operator.*;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
@@ -62,6 +63,16 @@ public class CollectionMethodsTest extends IntegrationTest {
     $$(By.xpath("//select[@name='domain']/option")).shouldHaveSize(4);
     $$(By.name("non-existing-element")).shouldHaveSize(0);
     $$("#dynamic-content-container span").shouldHave(size(2));
+    $$("#dynamic-content-container span").shouldHave(size(EQUALS, 2));
+    $$("#dynamic-content-container span").shouldHave(size(NOT_EQUAL, 42));
+    $$("#dynamic-content-container span").shouldHave(size(GREATER, 1)).shouldHave(size(LESS, 3));
+    $$("#dynamic-content-container span").shouldHave(size(GREATER_OR_EQUALS, 1)).shouldHave(size(LESS_OR_EQUALS, 3));
+    $$("#dynamic-content-container span").shouldHave(size(GREATER_OR_EQUALS, 2)).shouldHave(size(LESS_OR_EQUALS, 2));
+    $$("#dynamic-content-container span").shouldHaveSize(EQUALS, 2);
+    $$("#dynamic-content-container span").shouldHaveSize(NOT_EQUAL, 42);
+    $$("#dynamic-content-container span").shouldHaveSize(GREATER, 1).shouldHaveSize(LESS, 3);
+    $$("#dynamic-content-container span").shouldHaveSize(GREATER_OR_EQUALS, 1).shouldHaveSize(LESS_OR_EQUALS, 3);
+    $$("#dynamic-content-container span").shouldHaveSize(GREATER_OR_EQUALS, 2).shouldHaveSize(LESS_OR_EQUALS, 2);
   }
 
   @Test


### PR DESCRIPTION
Yo Andrey!

Please review my commit with comparison operator for collections of WebElements.
I have added new feature for the method shouldHaveSize(int):

.shouldHaveSize(GREATER, 1);
.shouldHaveSize(EQUALS, 1); works like good old .shouldHaveSize(1);
.shouldHaveSize(GREATER, 1).shouldHaveSize(LESS_OR_EQUALS, 5);