### PR TITLE
Fix exception message typo

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/WebDriverThreadLocalContainer.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebDriverThreadLocalContainer.java
@@ -67,7 +67,7 @@ public class WebDriverThreadLocalContainer implements WebDriverContainer {
       log.log(FINE, "Browser is unreachable", e);
       return false;
     } catch (NoSuchWindowException e) {
-      log.log(FINE, "Browser window is now found", e);
+      log.log(FINE, "Browser window is not found", e);
       return false;
     } catch (SessionNotFoundException e) {
       log.log(FINE, "Browser session is not found", e);


### PR DESCRIPTION
I believe the NoSuchWindowException is meant to read "Browser window is not found"