### PR TITLE
Implementation of basic auth. for many browsers

### DIFF
--- a/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/src/main/java/com/codeborne/selenide/Selenide.java
@@ -35,6 +35,7 @@ public class Selenide {
 
   public static Navigator navigator = new Navigator();
 
+
   /**
    * The main starting point in your tests.
    * Open a browser window with given URL.
@@ -48,15 +49,41 @@ public class Selenide {
    *   In this case, it's prepended by baseUrl
    */
   public static void open(String relativeOrAbsoluteUrl) {
-    navigator.open(relativeOrAbsoluteUrl);
-    mockModalDialogs();
+    open(relativeOrAbsoluteUrl, "", "" , "");
   }
 
   /**
    * @see Selenide#open(String)
    */
   public static void open(URL absoluteUrl) {
-    navigator.open(absoluteUrl);
+    open(absoluteUrl, "", "" , "");
+  }
+
+  /**
+   * The main starting point in your tests.
+   * Open a browser window with given URL and credentials for basic authentication
+   *
+   * If browser window was already opened before, it will be reused.
+   *
+   * Don't bother about closing the browser - it will be closed automatically when all your tests are done.
+   *
+   * @param relativeOrAbsoluteUrl
+   * @param domain
+   * @param login
+   * @param password
+   *   If not starting with "http://" or "https://" or "file://", it's considered to be relative URL.
+   *   In this case, it's prepended by baseUrl
+   */
+  public static void open(String relativeOrAbsoluteUrl, String domain, String login, String password) {
+    navigator.open(relativeOrAbsoluteUrl, domain, login, password);
+    mockModalDialogs();
+  }
+
+  /**
+   * @see Selenide#open(URL, String, String, String)
+   */
+  public static void open(URL absoluteUrl, String domain, String login, String password) {
+    navigator.open(absoluteUrl, domain, login, password);
     mockModalDialogs();
   }
 
@@ -98,8 +125,7 @@ public class Selenide {
    */
   public static <PageObjectClass> PageObjectClass open(String relativeOrAbsoluteUrl,
                                                        Class<PageObjectClass> pageObjectClassClass) {
-    open(relativeOrAbsoluteUrl);
-    return page(pageObjectClassClass);
+    return open(relativeOrAbsoluteUrl, "", "", "", pageObjectClassClass);
   }
 
   /**
@@ -108,7 +134,26 @@ public class Selenide {
    */
   public static <PageObjectClass> PageObjectClass open(URL absoluteUrl,
                                                        Class<PageObjectClass> pageObjectClassClass) {
-    open(absoluteUrl);
+    return open(absoluteUrl, "", "", "", pageObjectClassClass);
+  }
+
+  /**
+   * Open a web page using Basic Auth credentials and create PageObject for it.
+   * @return PageObject of given class
+   */
+  public static <PageObjectClass> PageObjectClass open(String relativeOrAbsoluteUrl, String domain, String login, String password,
+                                                       Class<PageObjectClass> pageObjectClassClass) {
+    open(relativeOrAbsoluteUrl, domain, login, password);
+    return page(pageObjectClassClass);
+  }
+
+  /**
+   * Open a web page using Basic Auth credentials and create PageObject for it.
+   * @return PageObject of given class
+   */
+  public static <PageObjectClass> PageObjectClass open(URL absoluteUrl, String domain, String login, String password,
+                                                       Class<PageObjectClass> pageObjectClassClass) {
+    open(absoluteUrl, domain, login, password);
     return page(pageObjectClassClass);
   }
 
@@ -579,10 +624,10 @@ public class Selenide {
         result.add(error.toString());
       }
       return result;
-    } catch (WebDriverException cannotExecuteJs) {
+    } catch (WebDriverException | UnsupportedOperationException cannotExecuteJs) {
       log.severe(cannotExecuteJs.toString());
       return emptyList();
-    }
+    } 
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/impl/Navigator.java
+++ b/src/main/java/com/codeborne/selenide/impl/Navigator.java
@@ -57,13 +57,12 @@ public class Navigator {
       if (!domain.isEmpty()) domain += "%5C";
       if (!login.isEmpty()) login += ":";
       if (!password.isEmpty()) password += "@";
-      int idx1 = url.indexOf("//") + 2;
-      url = url.substring(0, idx1 - 2)
-              + "//"
+      int idx1 = url.indexOf("://") + 3;
+      url = (idx1 < 3 ? "" : (url.substring(0, idx1 - 3) + "://"))
               + domain
               + login
               + password
-              + url.substring(idx1);
+              + (idx1 < 3 ? url : url.substring(idx1));
     }
 
     SelenideLog log = SelenideLogger.beginStep("open", url);

--- a/src/main/java/com/codeborne/selenide/impl/Navigator.java
+++ b/src/main/java/com/codeborne/selenide/impl/Navigator.java
@@ -1,10 +1,12 @@
 package com.codeborne.selenide.impl;
 
+import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.logevents.SelenideLog;
 import com.codeborne.selenide.logevents.SelenideLogger;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.security.UserAndPassword;
 
 import java.net.URL;
 import java.util.logging.Logger;
@@ -17,16 +19,24 @@ public class Navigator {
   private static final Logger log = Logger.getLogger(Navigator.class.getName());
 
   public void open(String relativeOrAbsoluteUrl) {
-    if (relativeOrAbsoluteUrl.startsWith("http:") ||
-        relativeOrAbsoluteUrl.startsWith("https:") ||
-        isLocalFile(relativeOrAbsoluteUrl)) {
-      navigateToAbsoluteUrl(relativeOrAbsoluteUrl);
-    } else {
-      navigateToAbsoluteUrl(absoluteUrl(relativeOrAbsoluteUrl));
-    }
+    open(relativeOrAbsoluteUrl, "", "" ,"");
   }
 
   public void open(URL url) {
+    open(url, "", "" ,"");
+  }
+
+  public void open(String relativeOrAbsoluteUrl, String domain, String login, String password) {
+    if (relativeOrAbsoluteUrl.startsWith("http:") ||
+            relativeOrAbsoluteUrl.startsWith("https:") ||
+            isLocalFile(relativeOrAbsoluteUrl)) {
+      navigateToAbsoluteUrl(relativeOrAbsoluteUrl, domain, login, password);
+    } else {
+      navigateToAbsoluteUrl(absoluteUrl(relativeOrAbsoluteUrl), domain, login, password);
+    }
+  }
+
+  public void open(URL url, String domain, String login, String password) {
     navigateToAbsoluteUrl(url.toExternalForm());
   }
 
@@ -35,14 +45,32 @@ public class Navigator {
   }
 
   protected void navigateToAbsoluteUrl(String url) {
+    navigateToAbsoluteUrl(url, "", "", "");
+  }
+
+  protected void navigateToAbsoluteUrl(String url, String domain, String login, String password) {
     if (isIE() && !isLocalFile(url)) {
       url = makeUniqueUrlToAvoidIECaching(url, System.nanoTime());
+      if (!domain.isEmpty()) domain += "\\";
+    }
+    else {
+      if (!domain.isEmpty()) domain += "%5C";
+      if (!login.isEmpty()) login += ":";
+      if (!password.isEmpty()) password += "@";
+      int idx1 = url.indexOf("//") + 2;
+      url = url.substring(0, idx1 - 2)
+              + "//"
+              + domain
+              + login
+              + password
+              + url.substring(idx1);
     }
 
     SelenideLog log = SelenideLogger.beginStep("open", url);
     try {
       WebDriver webdriver = getAndCheckWebDriver();
       webdriver.navigate().to(url);
+      if (isIE()) Selenide.switchTo().alert().authenticateUsing(new UserAndPassword(domain + login, password));
       collectJavascriptErrors((JavascriptExecutor) webdriver);
       SelenideLogger.commitStep(log, PASS);
     } catch (WebDriverException e) {

--- a/src/main/java/com/codeborne/selenide/webdriver/WebDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/WebDriverFactory.java
@@ -6,6 +6,7 @@ import org.openqa.selenium.Dimension;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 import org.openqa.selenium.ie.InternetExplorerDriver;
 import org.openqa.selenium.internal.*;
@@ -91,7 +92,17 @@ public class WebDriverFactory {
   }
 
   protected WebDriver createFirefoxDriver(Proxy proxy) {
+    FirefoxProfile myProfile = new FirefoxProfile();
+    myProfile.setPreference("network.automatic-ntlm-auth.trusted-uris", "http://,https://");
+    myProfile.setPreference("network.automatic-ntlm-auth.allow-non-fqdn", true);
+    myProfile.setPreference("network.negotiate-auth.delegation-uris", "http://,https://");
+    myProfile.setPreference("network.negotiate-auth.trusted-uris", "http://,https://");
+    myProfile.setPreference("network.http.phishy-userpass-length", 255);
+    myProfile.setPreference("security.csp.enable", false);
+
     DesiredCapabilities capabilities = createCommonCapabilities(proxy);
+    capabilities.setCapability(FirefoxDriver.PROFILE, myProfile);
+
     return new FirefoxDriver(capabilities);
   }
 

--- a/src/test/java/integration/BasicAuthTest.java
+++ b/src/test/java/integration/BasicAuthTest.java
@@ -17,8 +17,7 @@ import org.testng.annotations.BeforeTest;
 
 import java.util.concurrent.TimeUnit;
 
-import static com.codeborne.selenide.Condition.name;
-import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Condition.*;
 import static com.codeborne.selenide.Selenide.*;
 import static com.codeborne.selenide.WebDriverRunner.currentFrameUrl;
 import static com.codeborne.selenide.WebDriverRunner.getWebDriver;
@@ -98,7 +97,7 @@ public class BasicAuthTest extends IntegrationTest  {
                 "",
                 "user",
                 "passwd");
-        assertThat(isAlertPresent(), is(false));
+        assertThat(source(), containsString("WebDriver"));
     }
 
     public boolean isAlertPresent() {

--- a/src/test/java/integration/BasicAuthTest.java
+++ b/src/test/java/integration/BasicAuthTest.java
@@ -66,7 +66,6 @@ public class BasicAuthTest extends IntegrationTest  {
                 "",
                 "user",
                 "passwd");
-        System.out.println(getWebDriver().getPageSource());
         assertThat(source(), containsString("\"authenticated\": true,"));
     }
 

--- a/src/test/java/integration/BasicAuthTest.java
+++ b/src/test/java/integration/BasicAuthTest.java
@@ -1,0 +1,113 @@
+package integration;
+
+import com.codeborne.selenide.Configuration;
+import com.codeborne.selenide.Selenide;
+import com.codeborne.selenide.WebDriverRunner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoAlertPresentException;
+import org.openqa.selenium.TimeoutException;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.codeborne.selenide.Condition.name;
+import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Selenide.*;
+import static com.codeborne.selenide.WebDriverRunner.currentFrameUrl;
+import static com.codeborne.selenide.WebDriverRunner.getWebDriver;
+import static com.codeborne.selenide.WebDriverRunner.source;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.openqa.selenium.support.ui.ExpectedConditions.alertIsPresent;
+
+/**
+ * Created by Fiatlux on 28.04.2016.
+ */
+public class BasicAuthTest extends IntegrationTest  {
+
+    private String browserOriginalValue = "firefox";
+
+    @Before
+    public void setUp() {
+        browserOriginalValue = Configuration.browser;
+    }
+
+    @After
+    public void tearDown() {
+        WebDriverRunner.closeWebDriver();
+        Configuration.browser = browserOriginalValue;
+    }
+
+    @Test
+    public void canPassBasicAuthInFirefox() {
+        Configuration.browser = "firefox";
+        Selenide.open("http://httpbin.org/basic-auth/user/passwd",
+                "",
+                "user",
+                "passwd");
+        $(By.tagName("pre")).waitUntil(visible, 10000);
+        assertThat(source(), containsString("\"authenticated\": true,"));
+    }
+
+    @Test
+    public void canPassBasicAuthInHtmlUnit() {
+        Configuration.browser = "htmlunit";
+        Selenide.open("http://httpbin.org/basic-auth/user/passwd",
+                "",
+                "user",
+                "passwd");
+        System.out.println(getWebDriver().getPageSource());
+        assertThat(source(), containsString("\"authenticated\": true,"));
+    }
+
+    @Test @Ignore
+    public void canPassBasicAuthInPhantom() {
+        Configuration.browser = "phantomjs";
+        Selenide.open("http://httpbin.org/basic-auth/user/passwd",
+                "",
+                "user",
+                "passwd");
+        $(By.tagName("pre")).waitUntil(visible, 10000);
+        assertThat(source(), containsString("\"authenticated\": true,"));
+    }
+
+    @Test @Ignore
+    public void canPassBasicAuthInChrome() {
+        Configuration.browser = "chrome";
+        Selenide.open("http://httpbin.org/basic-auth/user/passwd",
+                "",
+                "user",
+                "passwd");
+        $(By.tagName("pre")).waitUntil(visible, 10000);
+        assertThat(source(), containsString("\"authenticated\": true,"));
+    }
+
+    @Test @Ignore
+    public void canPassBasicAuthInIe() {
+        Configuration.browser = "ie";
+        Selenide.open("http://httpbin.org/basic-auth/user/passwd",
+                "",
+                "user",
+                "passwd");
+        assertThat(isAlertPresent(), is(false));
+    }
+
+    public boolean isAlertPresent() {
+        try {
+            Wait().until(alertIsPresent());
+            return true;
+        } catch (TimeoutException | NoAlertPresentException ex) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Now we can use 
```java
Selenide.open("http://somepage.org", "SomeDomain", "JohnLogin", "JohnPassword");
```
if we want to pass basic authentication.
Supported (and tested) browsers:
1) IE11
2) Chrome
3) Firefox
4) PhantomJs
5) HtmlUnit

Additional:
- UnsupportedOperationException added to catch() clause in getJavascriptErrors() method (specially for HtmlUnit)
- Tests for Chrome, IE, PhantomJs disabled because executables are needed