### PR TITLE
added a new headless Jbrowser driver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,8 @@ dependencies {
   testRuntime group: 'net.sourceforge.htmlunit', name: 'htmlunit', version: '2.21'
   provided 'junit:junit:4.12'
   provided 'org.testng:testng:6.9.10'
+  
+  runtime 'com.machinepublishers:jbrowserdriver:0.13.0'
 
   testCompile group: 'net.lightbody.bmp', name: 'browsermob-core-littleproxy', version: '2.1.0-beta-6'
   testCompile 'org.mockito:mockito-core:1.10.19'

--- a/build.gradle
+++ b/build.gradle
@@ -213,6 +213,12 @@ task firefox(type: Test) {
   exclude 'com/codeborne/selenide/**/*'
 }
 
+task jbrowser(type: Test) {
+  systemProperties['selenide.browser'] = 'jbrowser'
+  include 'integration/**/*'
+  exclude 'com/codeborne/selenide/**/*'
+}
+
 task testng(type: Test) {
   useTestNG()
   include '**/*'

--- a/src/main/java/com/codeborne/selenide/WebDriverRunner.java
+++ b/src/main/java/com/codeborne/selenide/WebDriverRunner.java
@@ -49,6 +49,14 @@ public class WebDriverRunner {
    * &lt;dependency org="com.opera" name="operadriver" rev="1.5" conf="test-&gt;default"/&gt;
    */
   public static final String OPERA = "opera";
+  
+  /**
+   * To use JbrowserDriver, you need to include extra dependency to your project:
+   * <dependency org="com.machinepublishers" name="jbrowserdriver" rev="[0.13.0, 2.0)" conf="test-&gt;default"/&gt;
+   * 
+   * Note: You need minimum of Java 8.
+   */
+  public static final String JBROWSER = "jbrowser";
 
   /**
    * Use this method BEFORE opening a browser to add custom event listeners to webdriver.
@@ -193,6 +201,13 @@ public class WebDriverRunner {
    */
   public static boolean isOpera() {
     return OPERA.equalsIgnoreCase(browser);
+  }
+  
+  /**
+   * Is Selenide configured to use JBrowser browser
+   */
+  public static boolean isOpera() {
+    return JBROWSER.equalsIgnoreCase(browser);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/WebDriverRunner.java
+++ b/src/main/java/com/codeborne/selenide/WebDriverRunner.java
@@ -206,7 +206,7 @@ public class WebDriverRunner {
   /**
    * Is Selenide configured to use JBrowser browser
    */
-  public static boolean isOpera() {
+  public static boolean isJBrowser() {
     return JBROWSER.equalsIgnoreCase(browser);
   }
 


### PR DESCRIPTION
Hi,

This is a new headless driver [JBrowser](https://github.com/MachinePublishers/jBrowserDriver) Driver which uses web-kit and doesn't need any additional browser dependencies.But is needs a minimum of Java 8 to run.

Thanks,
Anil