### PR TITLE
Don't show "Screenshots: " in the error log when screenshots are disa…

### DIFF
--- a/src/main/java/com/codeborne/selenide/ex/ErrorMessages.java
+++ b/src/main/java/com/codeborne/selenide/ex/ErrorMessages.java
@@ -1,6 +1,7 @@
 package com.codeborne.selenide.ex;
 
 import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.Screenshots;
 import com.codeborne.selenide.impl.Cleanup;
 import org.openqa.selenium.WebDriverException;
@@ -35,6 +36,9 @@ public class ErrorMessages {
   }
   
   public static String screenshot(String screenshotPath) {
+    if(!Configuration.screenshots) {
+      return "";
+    }
     return "\nScreenshot: " + screenshotPath;
   }
 


### PR DESCRIPTION
When screenshots are disabled isn't added empty record in error log like this one:

> Element not found {By.xpath: //div[@class='dataTables_scrollBody']}
> Expected: exist
> 
> **Screenshot:** 
> Timeout: 5 s.
> Caused by: NoSuchElementException: no such element: Unable to locate element: {"method":"xpath","selector":"//div[@class='dataTables_scrollBody']"}
