### PR TITLE
Fixed bug with IE and basic auth

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/Navigator.java
+++ b/src/main/java/com/codeborne/selenide/impl/Navigator.java
@@ -69,7 +69,7 @@ public class Navigator {
     try {
       WebDriver webdriver = getAndCheckWebDriver();
       webdriver.navigate().to(url);
-      if (isIE()) Selenide.switchTo().alert().authenticateUsing(new UserAndPassword(domain + login, password));
+      if (isIE() && !"".equals(login)) Selenide.switchTo().alert().authenticateUsing(new UserAndPassword(domain + login, password));
       collectJavascriptErrors((JavascriptExecutor) webdriver);
       SelenideLogger.commitStep(log, PASS);
     } catch (WebDriverException e) {


### PR DESCRIPTION
Problem mentioned in #366 and highlighted in #320.
So here is quick fix of that. I think if there is empty login parameter we don't need to handling alert for basic auth.