### PR TITLE
Cut off WebElement screenshot size when it doesn't fit in full page screenshot

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
+++ b/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
@@ -9,6 +9,7 @@ import org.openqa.selenium.remote.UnreachableBrowserException;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
+import java.awt.image.RasterFormatException;
 import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -69,7 +70,7 @@ public class ScreenShotLaboratory {
   /**
    * Takes screenshot of current browser window.
    * Stores 2 files: html of page (if "savePageSource" option is enabled), and (if possible) image in PNG format.
-   * 
+   *
    * @param fileName name of file (without extension) to store screenshot to.
    * @return the name of last saved screenshot or null if failed to create screenshot
    */
@@ -122,14 +123,25 @@ public class ScreenShotLaboratory {
 
     Point p = element.getLocation();
     Dimension elementSize = element.getSize();
-
     try {
       BufferedImage img = ImageIO.read(new ByteArrayInputStream(screen));
-      BufferedImage dest = img.getSubimage(p.getX(), p.getY(), elementSize.getWidth(), elementSize.getHeight());
+      int elementWidth = elementSize.getWidth();
+      int elementHeight = elementSize.getHeight();
+      if (elementWidth > img.getWidth()) {
+        elementWidth = img.getWidth() - p.getX();
+      }
+      if (elementHeight > img.getHeight()) {
+        elementHeight = img.getHeight() - p.getY();
+      }
+      BufferedImage dest = img.getSubimage(p.getX(), p.getY(), elementWidth, elementHeight);
       return dest;
     }
     catch (IOException e) {
       printOnce("takeScreenshotImage", e);
+      return null;
+    }
+    catch (RasterFormatException e) {
+      log.warning("Cannot take screenshot because element is not displayed on current screen position");
       return null;
     }
   }
@@ -296,7 +308,7 @@ public class ScreenShotLaboratory {
   public List<File> getScreenshots() {
     return allScreenshots;
   }
-  
+
   public File getLastScreenshot() {
     return allScreenshots.isEmpty() ? null : allScreenshots.get(allScreenshots.size() - 1);
   }

--- a/src/test/java/integration/ScreenshotTest.java
+++ b/src/test/java/integration/ScreenshotTest.java
@@ -2,9 +2,9 @@ package integration;
 
 import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.ScreenShotLaboratory;
 import org.junit.Before;
 import org.junit.Test;
-import org.openqa.selenium.By;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -13,37 +13,51 @@ import java.io.IOException;
 
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.WebDriverRunner.isHtmlUnit;
-import static integration.SelenideMethodsTest.assertBetween;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 
 public class ScreenshotTest extends IntegrationTest {
+
   @Before
   public void openTestPage() {
     assumeFalse(isHtmlUnit());
-    openFile("page_with_selects_without_jquery.html");
+    openFile("page_with_big_divs.html");
   }
 
   @Test
   public void canTakeScreenshotOfElement() throws IOException {
-    SelenideElement select = $(By.xpath("//select[@name='domain']"));
-    File screenshot = select.screenshot();
+    SelenideElement element = $("#small_div");
+    File screenshot = element.screenshot();
     String info = "(Screenshot of element: " + screenshot.getAbsolutePath() + ") ";
 
     BufferedImage img = ImageIO.read(screenshot);
-    assertBetween("Screenshot doesn't fit width " + info, img.getWidth(), 50, 200);
-    assertBetween("Screenshot doesn't fit height " + info, img.getHeight(), 10, 30);
-    assertTrue("Screenshot file should be located in " + Configuration.reportsFolder + 
-        ", but was: " + screenshot.getPath(), 
+    assertEquals("Screenshot doesn't fit width " + info, img.getWidth(), element.getSize().getWidth());
+    assertEquals("Screenshot doesn't fit height " + info, img.getHeight(),  element.getSize().getHeight());
+    assertTrue("Screenshot file should be located in " + Configuration.reportsFolder +
+        ", but was: " + screenshot.getPath(),
         screenshot.getPath().startsWith(Configuration.reportsFolder));
   }
 
   @Test
-  public void canTakeScreenshotOfElementAsImage() throws IOException {
-    SelenideElement select = $(By.xpath("//select[@name='domain']"));
-    BufferedImage img = select.screenshotAsImage();
+  public void testResizeBigImageWidth() {
+    SelenideElement element = $("#wide_div");
+    BufferedImage img = element.screenshotAsImage();
+    assertTrue("Screenshot doesn't fit width", img.getWidth() < element.getSize().getWidth());
+  }
 
-    assertBetween("Screenshot doesn't fit width", img.getWidth(), 50, 200);
-    assertBetween("Screenshot doesn't fit height", img.getHeight(), 10, 30);
+  @Test
+  public void testResizeBigImageHeight() {
+    SelenideElement element = $("#big_div");
+    BufferedImage img =  new ScreenShotLaboratory().takeScreenshotAsImage(element);
+    assertTrue("Screenshot doesn't fit height", img.getHeight() < element.getSize().getHeight());
+  }
+
+  @Test
+  public void testResizeBigImage() {
+    SelenideElement element = $("#huge_div");
+    BufferedImage img = $("#huge_div").screenshotAsImage();
+    assertTrue("Screenshot doesn't fit width", img.getWidth() < element.getSize().getWidth());
+    assertTrue("Screenshot doesn't fit height", img.getHeight() < element.getSize().getHeight());
   }
 }

--- a/src/test/resources/page_with_big_divs.html
+++ b/src/test/resources/page_with_big_divs.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test::Screenshots</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+    <!--<style> Please don't edit styles above-->
+    <style>
+    #small_div {
+        width:185px;
+        height:200px;
+        background:#666;
+        margin:-bottom:20px;
+     }
+     #wide_div {
+        width:3000px;
+        height:50px;
+        background:#888;
+        margin:-bottom:20px;
+     }
+     #medium_div {
+        width:185px;
+        height:300px;
+        background:#333;
+        margin:-bottom:20px;
+     }
+     #big_div {
+        width:185px;
+        height:1600px;
+        background:#999;
+        margin-bottom:20px;
+     }
+     #huge_div {
+        width:3000px;
+        height:3000px;
+        background:yellow;
+     }
+    </style>
+</head>
+<body>
+<h1>Some big divs</h1>
+<div id="huge_div">
+    <div id="wide_div">Long div</div>
+    <div id="small_div">Small div</div>
+    <div id="medium_div">Medium div</div>
+    <div id="big_div">Big div</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
#373
- cut off WebElement screenshot size when it doesn't fit in full page screenshot
- add warning message for cases when element isn’t displayed on current screenshot
