### PR TITLE
#243, #365: changed ElementsCollections#find. Test classes - getting collections & elements in different way. Given helpers - html site building.

### DIFF
--- a/src/main/java/com/codeborne/selenide/ElementsCollection.java
+++ b/src/main/java/com/codeborne/selenide/ElementsCollection.java
@@ -154,7 +154,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    * @return SelenideElement
    */
   public SelenideElement find(Condition condition) {
-    return filter(condition).get(0);
+    return CollectionElementByCondition.wrap(collection, condition);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/impl/CollectionElementByCondition.java
+++ b/src/main/java/com/codeborne/selenide/impl/CollectionElementByCondition.java
@@ -1,0 +1,61 @@
+package com.codeborne.selenide.impl;
+
+import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.ex.ElementNotFound;
+import org.openqa.selenium.WebElement;
+
+import java.lang.reflect.Proxy;
+import java.util.List;
+
+import static com.codeborne.selenide.Condition.visible;
+
+public class CollectionElementByCondition extends WebElementSource {
+
+    public static SelenideElement wrap(WebElementsCollection collection, Condition condition) {
+        return (SelenideElement) Proxy.newProxyInstance(
+                collection.getClass().getClassLoader(), new Class<?>[]{SelenideElement.class},
+                new SelenideElementProxy(new CollectionElementByCondition(collection, condition)));
+    }
+
+    private final WebElementsCollection collection;
+    private final Condition condition;
+
+    CollectionElementByCondition(WebElementsCollection collection, Condition condition) {
+        this.collection = collection;
+        this.condition = condition;
+    }
+
+    @Override
+    public WebElement getWebElement() {
+        List<WebElement> list = collection.getActualElements();
+
+        for (WebElement element : list) {
+            if (condition.apply(element)) {
+                return element;
+            }
+        }
+
+        throw new ElementNotFound(getSearchCriteria(), condition);
+    }
+
+    @Override
+    public String getSearchCriteria() {
+        return collection.description() + ".findBy(" + condition + ")";
+    }
+
+
+    @Override
+    public ElementNotFound createElementNotFoundError(Condition condition, Throwable lastError) {
+        if (collection.getActualElements().isEmpty()) {
+            return new ElementNotFound(collection.description(), visible, lastError);
+        }
+        return super.createElementNotFoundError(condition, lastError);
+    }
+
+    @Override
+    public String toString() {
+        return getSearchCriteria();
+    }
+
+}

--- a/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
@@ -38,7 +38,7 @@ public abstract class WebElementSource {
   public WebElement checkCondition(String prefix, String message, Condition condition, boolean invert) {
     Condition check = invert ? not(condition) : condition;
 
-    RuntimeException lastError = null;
+    Throwable lastError = null;
     WebElement element = null;
     try {
       element = getWebElement();
@@ -46,7 +46,7 @@ public abstract class WebElementSource {
         return element;
       }
     }
-    catch (RuntimeException e) {
+    catch (Throwable e) {
       lastError = e;
     }
 

--- a/src/test/java/integration/ScreenshotTest.java
+++ b/src/test/java/integration/ScreenshotTest.java
@@ -10,6 +10,7 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.WebDriverRunner.isHtmlUnit;
@@ -34,8 +35,8 @@ public class ScreenshotTest extends IntegrationTest {
     assertBetween("Screenshot doesn't fit width " + info, img.getWidth(), 50, 200);
     assertBetween("Screenshot doesn't fit height " + info, img.getHeight(), 10, 30);
     assertTrue("Screenshot file should be located in " + Configuration.reportsFolder + 
-        ", but was: " + screenshot.getPath(), 
-        screenshot.getPath().startsWith(Configuration.reportsFolder));
+        ", but was: " + screenshot.getPath(),
+        screenshot.getPath().startsWith(Paths.get(Configuration.reportsFolder).toString()));
   }
 
   @Test

--- a/src/test/java/integration/errormessages/MethodCalledOnCollectionFailsOnTest.java
+++ b/src/test/java/integration/errormessages/MethodCalledOnCollectionFailsOnTest.java
@@ -1,0 +1,217 @@
+package integration.errormessages;
+
+import com.codeborne.selenide.Configuration;
+import com.codeborne.selenide.ElementsCollection;
+import com.codeborne.selenide.ex.ElementNotFound;
+import com.codeborne.selenide.ex.ListSizeMismatch;
+import integration.IntegrationTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.NoSuchElementException;
+
+import static com.codeborne.selenide.CollectionCondition.exactTexts;
+import static com.codeborne.selenide.CollectionCondition.size;
+import static com.codeborne.selenide.Condition.cssClass;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.$$;
+import static integration.helpers.HTMLBuilderForTestPreconditions.Given;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+
+public class MethodCalledOnCollectionFailsOnTest extends IntegrationTest {
+
+    @Before
+    public void openPage() {
+        Given.openedPageWithBody(
+                "<ul>Hello to:",
+                "<li class='the-expanse detective'>Miller</li>",
+                "<li class='the-expanse missing'>Julie Mao</li>",
+                "</ul>"
+        );
+        Configuration.timeout = 0;
+    }
+
+    @Test
+    public void shouldCondition_When$$Collection_WithNonExistentWebElements() {
+        ElementsCollection collection = $$("ul .nonexistent");
+
+        try {
+            collection.shouldHave(exactTexts("Miller", "Julie Mao"));
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {ul .nonexistent}"));
+            assertThat(expected.getMessage(), containsString("Expected: [Miller, Julie Mao]"));
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), nullValue());
+        }
+        /*
+            Element not found {ul .nonexistent}
+            Expected: [Miller, Julie Mao]
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration/errormessages/MethodCalledOnCollectionFailsOnTest/shouldCondition_When$$Collection_WithNonExistentWebElements/1471354880814.0.png
+            Timeout: 6 s.
+        */
+        /*
+            todo -
+            We were looking for "collection of elements" but error message tells us about one "Element not found" o_O
+            this also applies to all other "collection" based tests.
+            Expected clause sounds too weird, because the context is not obvious, it would be better if such contexts preceded it:
+                While waiting for condition: exactTexts
+                Expected: [Miller, Julie Mao]
+        */
+    }
+
+
+
+    @Test
+    public void shouldCondition_WhenFilteredCollection_On$$CollectionWithNonExistentWebElements(){
+        ElementsCollection collection = $$("ul .nonexistent").filter(cssClass("the-expanse"));
+
+        try {
+            collection.shouldHave(exactTexts("Miller", "Julie Mao"));
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {ul .nonexistent.filter(css class 'the-expanse')}"));
+            assertThat(expected.getMessage(), containsString("Expected: [Miller, Julie Mao]"));
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), nullValue());
+        }
+        /*
+            Element not found {ul .nonexistent.filter(css class 'the-expanse')}
+            Expected: [Miller, Julie Mao]
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration/errormessages/MethodCalledOnCollectionFailsOnTest/shouldCondition_WhenFilteredCollection_WithNonExistentCollection/1471391641817.0.png
+            Timeout: 6 s.
+        */
+    }
+
+    @Test
+    public void shouldCondition_WhenFilteredCollection_WithNotSatisfiedCondition(){
+        ElementsCollection collection = $$("ul li").filter(cssClass("nonexistent"));
+
+        try {
+            collection.shouldHave(exactTexts("Miller", "Julie Mao"));
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {ul li.filter(css class 'nonexistent')}"));
+            assertThat(expected.getMessage(), containsString("Expected: [Miller, Julie Mao]"));
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), nullValue());
+        }
+        /*
+            Element not found {ul li.filter(css class 'nonexistent')}
+            Expected: [Miller, Julie Mao]
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration/errormessages/MethodCalledOnCollectionFailsOnTest/shouldCondition_WhenFilteredCollection_WithNotSatisfiedCondition/1477042881706.0.png
+            Timeout: 6 s.
+        */
+    }
+
+    @Test
+    public void shouldCondition_WhenInnerCollection_WithNonExistentOuterWebElement() {
+        ElementsCollection collection = $(".nonexistent").findAll("li");
+
+        try {
+            collection.shouldHave(exactTexts("Miller", "Julie Mao"));
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {.nonexistent}"));
+            assertThat(expected.getMessage(), containsString("Expected: exist"));//todo - is it correct?
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(NoSuchElementException.class));
+            assertThat(expected.getCause().getMessage(), containsString("Unable to locate element: {\"method\":\"css selector\",\"selector\":\".nonexistent\"}"));
+        }
+        /*
+            Element not found {.nonexistent}
+            Expected: exist
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration/errormessages/MethodCalledOnCollectionFailsOnTest/shouldCondition_WhenInnerCollection_WithNonExistentOuterWebElement/1471818981483.1.png
+            Timeout: 6 s.
+            Caused by: NoSuchElementException: Unable to locate element: {"method":"css selector","selector":".nonexistent"}
+        */
+    }
+
+    @Test
+    public void shouldCondition_WhenInnerCollection_WithNonExistentInnerWebElements() {
+        ElementsCollection collection = $("ul").findAll(".nonexistent");
+
+        try {
+            collection.shouldHave(exactTexts("Miller", "Julie Mao"));
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {<ul>/.nonexistent}"));
+            assertThat(expected.getMessage(), containsString("Expected: [Miller, Julie Mao]"));
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), nullValue());
+        }
+        /*
+            Element not found {<ul>/.nonexistent}
+            Expected: [Miller, Julie Mao]
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration/errormessages/MethodCalledOnCollectionFailsOnTest/shouldCondition_WhenInnerCollection_WithNonExistentInnerWebElements/1471819518459.0.png
+            Timeout: 6 s.
+        */
+    }
+
+    /*******************************************************************************************************************
+     * todo - hypothesis - error should be according to condition plus caused by ElementNotFound
+     * Question - what should the correct error be?
+     * now we have different options - exactTexts - Element not found, size - ListSizeMismatch without caused error
+     * <p/>
+     * look at
+     * shouldHaveSizeCondition_When$$Collection_WithNotSatisfiedConditionInShould() - correct exception according to condition
+     * shouldHaveSizeCondition_When$$Collection_WithNonExistentCollection() - correct exception according to condition,
+     * BUT there is no caused by  - ElementNotFound
+     * BUT
+     * shouldCondition_When$$Collection_WithNonExistentWebElements() (using exactText) - we have ElementNotFound exception
+     * instead error according to condition
+     * <p/>
+     * What is a correct result?
+     */
+    @Test
+    public void shouldHaveSizeCondition_When$$Collection_WithNotSatisfiedConditionInShould() {
+        ElementsCollection collection = $$("ul li");
+
+        try {
+            collection.shouldHave(size(3));
+            fail("Expected ElementNotFound");
+        } catch (ListSizeMismatch expected) {
+            assertThat(expected.getMessage(), startsWith(": expected: = 3, actual: 2, collection: ul li"));
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), nullValue());
+        }
+        /*
+            ListSizeMismatch : expected: = 3, actual: 2, collection: ul li
+            Elements: [
+                <li class="the-expanse detective" value="0">Miller</li>,
+                <li class="the-expanse" value="0">Julie Mao</li>
+            ]
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration/errormessages/MethodCalledOnCollectionFailsOnTest/shouldCondition_When$$Collection_WithNotSatisfiedConditionInShould/1471356041663.0.png
+            Timeout: 6 s.
+        */
+    }
+
+    @Test
+    public void shouldHaveSizeCondition_When$$Collection_WithNonExistentCollection() {
+        ElementsCollection collection = $$("ul .nonexistent");
+
+        try {
+            collection.shouldHave(size(3));
+            fail("Expected ElementNotFound");
+        } catch (ListSizeMismatch expected) {
+            assertThat(expected.getMessage(), startsWith(": expected: = 3, actual: 0, collection: ul .nonexistent"));
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), nullValue());
+        }
+        /*
+            ListSizeMismatch : expected: = 3, actual: 0, collection: ul .nonexistent
+            Elements: []
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration/errormessages/MethodCalledOnCollectionFailsOnTest/shouldHaveSizeCondition_When$$Collection_WithNonExistentCollection/1471357025434.0.png
+            Timeout: 6 s.
+        */
+    }
+
+}

--- a/src/test/java/integration/errormessages/MethodCalledOnCollectionPassesOnTest.java
+++ b/src/test/java/integration/errormessages/MethodCalledOnCollectionPassesOnTest.java
@@ -1,0 +1,81 @@
+package integration.errormessages;
+
+import com.codeborne.selenide.Configuration;
+import com.codeborne.selenide.ElementsCollection;
+import integration.IntegrationTest;
+import integration.helpers.HTMLBuilderForTestPreconditions;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static com.codeborne.selenide.CollectionCondition.exactTexts;
+import static com.codeborne.selenide.Condition.cssClass;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.$$;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
+public class MethodCalledOnCollectionPassesOnTest extends IntegrationTest {
+
+    @Before
+    public void openPage() {
+        HTMLBuilderForTestPreconditions.Given.openedPageWithBody(
+                "<ul>Hello to:",
+                "<li class='the-expanse detective'>Miller</li>",
+                "<li class='the-expanse missing'>Julie Mao</li>",
+                "</ul>"
+        );
+        Configuration.timeout = 0;
+    }
+
+    @Test
+    public void shouldCondition_When$$Collection() {
+        ElementsCollection collection = $$("ul li");
+
+        collection.shouldHave(exactTexts("Miller", "Julie Mao"));
+    }
+
+    @Test
+    public void actionWithoutWaiting__When$$Collection() {
+        ElementsCollection collection = $$("ul li");
+
+        assertThat(Arrays.toString(collection.getTexts()), is("[Miller, Julie Mao]"));
+    }
+
+    @Test
+    public void actionWithoutWaiting_When$$Collection_WithNonExistentWebElements() {
+        ElementsCollection collection = $$("ul .nonexistent");
+
+        assertEquals(true, collection.isEmpty());
+        /*
+            there is no exceptions - when collection.isEmpty();
+        */
+    }
+
+    @Test
+    public void actionWithoutWaiting_WhenInnerCollection_WithNonExistentInnerWebElements() {
+        ElementsCollection collection = $("ul").findAll(".nonexistent");
+
+        assertEquals(0, collection.size());
+        /*
+            there is no exceptions - when collection.isEmpty();
+        */
+    }
+
+
+    @Test
+    public void shouldCondition_WhenFilteredCollection() {
+        ElementsCollection collection = $$("ul li").filter(cssClass("the-expanse"));
+
+        collection.shouldHave(exactTexts("Miller", "Julie Mao"));
+    }
+
+    @Test
+    public void shouldCondition_WhenInnerCollection() {
+        ElementsCollection collection = $("ul").findAll("li");
+
+        collection.shouldHave(exactTexts("Miller", "Julie Mao"));
+    }
+}

--- a/src/test/java/integration/errormessages/MethodCalledOnElementFailsOnTest.java
+++ b/src/test/java/integration/errormessages/MethodCalledOnElementFailsOnTest.java
@@ -1,0 +1,513 @@
+package integration.errormessages;
+
+
+import com.codeborne.selenide.Configuration;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.ex.ElementNotFound;
+import integration.IntegrationTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.NoSuchElementException;
+
+import static com.codeborne.selenide.Condition.*;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.$$;
+import static integration.helpers.HTMLBuilderForTestPreconditions.Given;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+
+
+public class MethodCalledOnElementFailsOnTest extends IntegrationTest {
+
+    @Before
+    public void openPage() {
+        Given.openedPageWithBody(
+                "<ul>Hello to:",
+                "<li class='the-expanse detective'>Miller <label>detective</label></li>",
+                "<li class='the-expanse missing'>Julie Mao</li>",
+                "</ul>"
+        );
+        Configuration.timeout = 0;
+    }
+
+    @Test
+    public void shouldCondition_When$Element_WithNonExistentElement() {
+        SelenideElement element = $("ul .nonexistent");
+
+        try {
+            element.shouldHave(text("Miller"));
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {ul .nonexistent}"));
+            assertThat(expected.getMessage(), containsString("Expected: text 'Miller'"));
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(NoSuchElementException.class));
+            assertThat(expected.getCause().getMessage(),
+                    containsString("Unable to locate element: {\"method\":\"css selector\",\"selector\":\"ul .nonexistent\"}"));
+        }
+        /*
+            caused by - different expression for chrome & ff
+
+            ff
+            Element not found {ul .nonexistent}
+            Expected: text 'Miller'
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration/errormessages/MethodCalledOnElementFailsOnTest/shouldCondition_When$Element_WithNonExistentWebElement/1471304286016.0.png
+            Timeout: 0 ms.
+            Caused by: NoSuchElementException: Unable to locate element: {"method":"css selector","selector":"ul .nonexistent"}
+
+            chrome
+            Element not found {ul .nonexistent}
+            Expected: text 'Miller'
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/chrome/integration/errormessages/MethodCalledOnElementFailsOnTest/shouldCondition_When$Element_WithNonExistentElement/1477036866229.0.png
+            Timeout: 0 ms.
+            Caused by: NoSuchElementException: no such element: Unable to locate element: {"method":"css selector","selector":"ul .nonexistent"}
+
+        */
+    }
+
+    @Test
+    public void shouldCondition_WhenCollectionElementByIndex_WithNonExistentCollection() {
+        SelenideElement element = $$("ul .nonexistent").get(1);
+
+        try {
+            element.shouldHave(text("Miller"));
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {ul .nonexistent}"));
+            assertThat(expected.getMessage(), containsString("Expected: visible"));//todo - is it correct?
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(IndexOutOfBoundsException.class));
+            assertThat(expected.getCause().getMessage(), startsWith("Index: 1, Size: 0"));
+        }
+        //todo - is it OK??
+        /*
+            Element not found {ul .nonexistent}
+            Expected: visible
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration/errormessages/MethodCalledOnElementFailsOnTest/shouldCondition_WhenCollectionElementByIndex_WithNonExistentCollection/1471345897750.0.png
+            Timeout: 0 ms.
+            Caused by: java.lang.IndexOutOfBoundsException: Index: 1, Size: 0
+        */
+
+    }
+
+    @Test
+    public void shouldCondition_WhenCollectionElementByIndex_WithIndexOutOfRange() {
+        SelenideElement element = $$("ul li").get(10);
+
+        try {
+            element.shouldHave(text("Miller"));
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {ul li[10]}"));
+            assertThat(expected.getMessage(), containsString("Expected: text 'Miller'"));
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(IndexOutOfBoundsException.class));
+            assertThat(expected.getCause().getMessage(), startsWith("Index: 10, Size: 2"));
+        }
+        /*
+            Element not found {ul li[10]}
+            Expected: text 'Miller'
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration/errormessages/MethodCalledOnElementFailsOnTest/shouldCondition_WhenCollectionElementByIndex_WithIndexOutOfRange/1471346375481.0.png
+            Timeout: 0 ms.
+            Caused by: java.lang.IndexOutOfBoundsException: Index: 10, Size: 2
+        */
+    }
+
+    @Test
+    public void actionWithVisibilityWaiting_WhenCollectionElementByIndex_WithIndexOutOfRange() {
+        SelenideElement element = $$("ul li").get(10);
+
+        try {
+            element.click();
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {ul li[10]}"));
+            assertThat(expected.getMessage(), containsString("Expected: visible"));
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(IndexOutOfBoundsException.class));
+            assertThat(expected.getCause().getMessage(), startsWith("Index: 10, Size: 2"));
+        }
+        /*
+            Element not found {ul li[10]}
+            Expected: visible
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration/errormessages/MethodCalledOnElementFailsOnTest/actionWithVisibilityWaiting_WhenCollectionElementByIndex_WithIndexOutOfRange/1471347320304.0.png
+            Timeout: 0 ms.
+            Caused by: java.lang.IndexOutOfBoundsException: Index: 10, Size: 2
+        */
+    }
+
+    @Test
+    public void shouldCondition_WhenCollectionElementByCondition_WithNonExistentCollection() {
+        SelenideElement element = $$(".nonexistent").findBy(cssClass("the-expanse"));
+
+        try {
+            element.shouldBe(exist);
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {.nonexistent}"));
+            assertThat(expected.getMessage(), containsString("Expected: visible"));//todo - is it correct?
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(ElementNotFound.class));
+            assertThat(expected.getCause().getMessage(), startsWith("Element not found {.nonexistent.findBy(css class 'the-expanse')}"));
+        }
+        /*
+            Element not found {.nonexistent}
+            Expected: visible
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration/errormessages/MethodCalledOnElementFailsOnTest/shouldCondition_WhenCollectionElementByCondition_WithNonExistentCollection/1471347808745.0.png
+            Timeout: 0 ms.
+            Caused by: Element not found {.nonexistent.findBy(css class 'the-expanse')}
+            Expected: css class 'the-expanse'
+            Screenshot: null
+            Timeout: 0 ms.
+        */
+    }
+
+    @Test
+    public void shouldCondition_WhenCollectionElementByCondition_WithNotSatisfiedCondition() {
+        SelenideElement element = $$("li").findBy(cssClass("nonexistent"));
+
+        try {
+            element.shouldBe(visible);
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {li.findBy(css class 'nonexistent')}"));
+            assertThat(expected.getMessage(), containsString("Expected: visible"));
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(ElementNotFound.class));
+            assertThat(expected.getCause().getMessage(), startsWith("Element not found {li.findBy(css class 'nonexistent')}"));
+        }
+        /*
+            Element not found {li.findBy(css class 'nonexistent')}
+            Expected: visible
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration/errormessages/MethodCalledOnElementFailsOnTest/shouldCondition_WhenCollectionElementByCondition_WithNotSatisfiedCondition/1471348458110.0.png
+            Timeout: 0 ms.
+            Caused by: Element not found {li.findBy(css class 'nonexistent')}
+            Expected: css class 'nonexistent'
+            Screenshot: null
+            Timeout: 0 ms.
+        */
+    }
+
+    @Test
+    public void actionWithExistenceWaiting_WhenCollectionElementByCondition_WithNotSatisfiedCondition() {
+        SelenideElement element = $$("li").findBy(cssClass("nonexistent"));
+
+        try {
+            element.text();
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {li.findBy(css class 'nonexistent')}"));
+            assertThat(expected.getMessage(), containsString("Expected: css class 'nonexistent'"));//todo - is it correct?
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), nullValue());
+        }
+        /*
+            Element not found {li.findBy(css class 'nonexistent')}
+            Expected: css class 'nonexistent'
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration/errormessages/MethodCalledOnElementFailsOnTest/actionWithExistenceWaiting_WhenCollectionElementByCondition_WithNotSatisfiedCondition/1471348636944.0.png
+            Timeout: 0 ms.
+        */
+    }
+
+    @Test
+    public void shouldCondition_WhenInnerElement_WithNonExistentOuterElement() {
+        SelenideElement element = $(".nonexistent").find(".the-expanse");
+
+        try {
+            element.should(appear);
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {.nonexistent}"));
+            assertThat(expected.getMessage(), containsString("Expected: exist"));//todo - is it correct?
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(NoSuchElementException.class));
+            assertThat(expected.getCause().getMessage(),
+                    containsString("Unable to locate element: {\"method\":\"css selector\",\"selector\":\".nonexistent\""));
+        }
+        /*
+            Element not found {.nonexistent}
+            Expected: exist
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration/errormessages/MethodCalledOnElementFailsOnTest/shouldCondition_WhenInnerElement_WithNonExistentOuterElement/1471351158103.1.png
+            Timeout: 0 ms.
+            Caused by: NoSuchElementException: Unable to locate element: {"method":"css selector","selector":".nonexistent"}
+        */
+    }
+
+    @Test
+    public void shouldCondition_WhenInnerElement_WithNonExistentInnerElement() {
+        SelenideElement element = $("ul").find(".nonexistent");
+
+        try {
+            element.shouldBe(visible);
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {.nonexistent}"));
+            assertThat(expected.getMessage(), containsString("Expected: visible"));
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(NoSuchElementException.class));
+            assertThat(expected.getCause().getMessage(),
+                    containsString("Unable to locate element: {\"method\":\"css selector\",\"selector\":\".nonexistent\""));
+        }
+        /*
+            Element not found {.nonexistent}
+            Expected: visible
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration/errormessages/MethodCalledOnElementFailsOnTest/shouldCondition_WhenInnerElement_WithNonExistentInnerElement/1471352505699.0.png
+            Timeout: 0 ms.
+            Caused by: NoSuchElementException: Unable to locate element: {"method":"css selector","selector":".nonexistent"}
+        */
+    }
+
+
+    @Test
+    public void actionWithVisibilityWaiting_WhenInnerElement_WithNonExistentInnerElement() {
+        SelenideElement element = $("ul").find(".nonexistent");
+
+        try {
+            element.doubleClick();
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {.nonexistent}"));
+            assertThat(expected.getMessage(), containsString("Expected: visible"));
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(NoSuchElementException.class));
+            assertThat(expected.getCause().getMessage(),
+                    containsString("Unable to locate element: {\"method\":\"css selector\",\"selector\":\".nonexistent\""));
+        }
+        /*
+            Element not found {.nonexistent}
+            Expected: visible
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration/errormessages/MethodCalledOnElementFailsOnTest/actionWithVisibilityWaiting_WhenInnerElement_WithNonExistentInnerElement/1471353844670.0.png
+            Timeout: 0 ms.
+            Caused by: NoSuchElementException: Unable to locate element: {"method":"css selector","selector":".nonexistent"}
+        */
+    }
+
+    /******************************************************
+     * More complicated useful options
+     * $$.filterBy(condition).findBy(condition).find
+     ******************************************************/
+
+    @Test
+    public void shouldCondition_WhenInnerElementFromOuterElementByConditionInFilteredCollection_WithNonExistentStartCollection() {
+        SelenideElement element = $$("ul .nonexistent").filterBy(cssClass("the-expanse")).findBy(cssClass("detective")).find("label");
+
+        try {
+            element.shouldHave(exactText("detective"));
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {ul .nonexistent.filter(css class 'the-expanse')}"));
+            assertThat(expected.getMessage(), containsString("Expected: visible"));//todo - is it correct?
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(ElementNotFound.class));
+            assertThat(expected.getCause().getMessage(),
+                    startsWith("Element not found {ul .nonexistent.filter(css class 'the-expanse').findBy(css class 'detective')}"));
+        }
+        /*
+            Element not found {ul .nonexistent.filter(css class 'the-expanse')}
+            Expected: visible
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration/errormessages/MethodCalledOnElementFailsOnTest/shouldCondition_WhenInnerElement_WithNonExistentStartCollection/1471821878793.1.png
+            Timeout: 0 ms.
+            Caused by: Element not found {ul .nonexistent.filter(css class 'the-expanse').findBy(css class 'detective')}
+            Expected: css class 'detective'
+            Screenshot: null
+            Timeout: 0 ms.
+        */
+    }
+
+    @Test
+    public void shouldCondition_WhenInnerElementFromOuterElementByConditionInFilteredCollection_WithEmptyFilteredCollection() {
+        SelenideElement element = $$("ul li").filterBy(cssClass("nonexistent")).findBy(cssClass("detective")).find("label");
+
+        try {
+            element.shouldHave(exactText("detective"));
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {ul li.filter(css class 'nonexistent')}"));
+            assertThat(expected.getMessage(), containsString("Expected: visible"));//todo - is it correct?
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(ElementNotFound.class));
+            assertThat(expected.getCause().getMessage(),
+                    startsWith("Element not found {ul li.filter(css class 'nonexistent').findBy(css class 'detective')}"));
+        }
+        /*
+            Element not found {ul li.filter(css class 'nonexistent')}
+            Expected: visible
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration/errormessages/MethodCalledOnElementFailsOnTest/shouldCondition_WhenInnerElementFromOuterElementByConditionInFilteredCollection_WithEmptyFilteredCollection/1471822913839.1.png
+            Timeout: 0 ms.
+            Caused by: Element not found {ul li.filter(css class 'nonexistent').findBy(css class 'detective')}
+            Expected: css class 'detective'
+            Screenshot: null
+            Timeout: 0 ms.
+        */
+    }
+
+    @Test
+    public void shouldCondition_WhenInnerElementFromOuterElementByConditionInFilteredCollection_WithNonExistentOuterElement() {
+        SelenideElement element = $$("ul li").filterBy(cssClass("the-expanse")).findBy(cssClass("nonexistent")).find("label");
+
+        try {
+            element.shouldHave(exactText("detective"));
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {ul li.filter(css class 'the-expanse').findBy(css class 'nonexistent')}"));
+            assertThat(expected.getMessage(), containsString("Expected: exist"));//todo - is it correct?
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(ElementNotFound.class));
+            assertThat(expected.getCause().getMessage(),
+                    startsWith("Element not found {ul li.filter(css class 'the-expanse').findBy(css class 'nonexistent')}"));
+        }
+        /*
+            Element not found {ul li.filter(css class 'the-expanse').findBy(css class 'nonexistent')}
+            Expected: exist
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration/errormessages/MethodCalledOnElementFailsOnTest/shouldCondition_WhenInnerElementFromOuterElementByConditionInFilteredCollection_WithNonExistentOuterElement/1471823230953.1.png
+            Timeout: 0 ms.
+            Caused by: Element not found {ul li.filter(css class 'the-expanse').findBy(css class 'nonexistent')}
+            Expected: css class 'nonexistent'
+            Screenshot: null
+            Timeout: 0 ms.
+        */
+    }
+
+    @Test
+    public void shouldCondition_WhenInnerElementFromOuterElementByConditionInFilteredCollection_WithNonExistentInnerElement() {
+        SelenideElement element = $$("ul li").filterBy(cssClass("the-expanse")).findBy(cssClass("detective")).find(".nonexistent");
+
+        try {
+            element.shouldHave(exactText("detective"));
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {.nonexistent}"));
+            assertThat(expected.getMessage(), containsString("Expected: exact text 'detective'"));
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(NoSuchElementException.class));
+            assertThat(expected.getCause().getMessage(),
+                    containsString("Unable to locate element: {\"method\":\"css selector\",\"selector\":\".nonexistent\"}"));
+        }
+        /*
+            Element not found {.nonexistent}
+            Expected: exact text 'detective'
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration/errormessages/MethodCalledOnElementFailsOnTest/shouldCondition_WhenInnerElementFromOuterElementByConditionInFilteredCollection_WithNonExistentInnerElement/1471823617503.0.png
+            Timeout: 0 ms.
+            Caused by: NoSuchElementException: Unable to locate element: {"method":"css selector","selector":".nonexistent"}
+        */
+    }
+
+    /******************************************************
+     * More complicated useful options
+     * $$.filterBy(condition).get(index).find
+     ******************************************************/
+    @Test
+    public void shouldCondition_WhenInnerElementFromOuterElementFoundByIndexInFilteredCollection_WithNonExistentStartCollection() {
+        SelenideElement element = $$("ul .nonexistent").filterBy(cssClass("the-expanse")).get(0).find("label");
+
+        try {
+            element.shouldHave(exactText("detective"));
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {ul .nonexistent.filter(css class 'the-expanse')}"));
+            assertThat(expected.getMessage(), containsString("Expected: visible"));//todo - is it correct?
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(IndexOutOfBoundsException.class));
+            assertThat(expected.getCause().getMessage(), startsWith("Index: 0, Size: 0"));
+        }
+        /*
+            Element not found {ul .nonexistent.filter(css class 'the-expanse')}
+            Expected: visible
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration/errormessages/MethodCalledOnElementFailsOnTest/shouldCondition_WhenInnerElementFromOuterElementFoundByIndexInFilteredCollection_WithNonExistentStartCollection/1471824227187.1.png
+            Timeout: 0 ms.
+            Caused by: java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
+        */
+    }
+
+    @Test
+    public void shouldCondition_WhenInnerElementFromOuterElementFoundByIndexInFilteredCollection_WithEmptyFilteredCollection() {
+        SelenideElement element = $$("ul li").filterBy(cssClass("nonexistent")).get(0).find("label");
+
+        try {
+            element.shouldHave(exactText("detective"));
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {ul li.filter(css class 'nonexistent')}"));
+            assertThat(expected.getMessage(), containsString("Expected: visible"));//todo - is it correct?
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(IndexOutOfBoundsException.class));
+            assertThat(expected.getCause().getMessage(), startsWith("Index: 0, Size: 0"));
+        }
+        /*
+            Element not found {ul li.filter(css class 'nonexistent')}
+            Expected: visible
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration/errormessages/MethodCalledOnElementFailsOnTest/shouldCondition_WhenInnerElementFromOuterElementFoundByIndexInFilteredCollection_WithEmptyFilteredCollection/1471824645294.1.png
+            Timeout: 0 ms.
+            Caused by: java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
+        */
+    }
+
+    @Test
+    public void shouldCondition_WhenInnerElementFromOuterElementFoundByIndexInFilteredCollection_WithIndexOutOfRange() {
+        SelenideElement element = $$("ul li").filterBy(cssClass("the-expanse")).get(2).find("label");
+
+        try {
+            element.shouldHave(exactText("detective"));
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {ul li.filter(css class 'the-expanse')[2]}"));
+            assertThat(expected.getMessage(), containsString("Expected: exist"));//todo - is it correct?
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(IndexOutOfBoundsException.class));
+            assertThat(expected.getCause().getMessage(), startsWith("Index: 2, Size: 2"));
+        }
+        /*
+            Element not found {ul li.filter(css class 'the-expanse')[2]}
+            Expected: exist
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration/errormessages/MethodCalledOnElementFailsOnTest/shouldCondition_WhenInnerElementFromOuterElementFoundByIndexInFilteredCollection_WithIndexOutOfRange/1471824926318.1.png
+            Timeout: 0 ms.
+            Caused by: java.lang.IndexOutOfBoundsException: Index: 2, Size: 2
+
+        */
+    }
+
+    @Test
+    public void shouldCondition_WhenInnerElementFromOuterElementFoundByIndexInFilteredCollection_WithNonExistentInnerElement() {
+        SelenideElement element = $$("ul li").filterBy(cssClass("the-expanse")).get(0).find(".nonexistent");
+
+        try {
+            element.shouldHave(exactText("detective"));
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {.nonexistent}"));
+            assertThat(expected.getMessage(), containsString("Expected: exact text 'detective'"));
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(NoSuchElementException.class));
+            assertThat(expected.getCause().getMessage(), containsString("Unable to locate element: {\"method\":\"css selector\",\"selector\":\".nonexistent\"}"));
+        }
+        /*
+            Element not found {.nonexistent}
+            Expected: exact text 'detective'
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration/errormessages/MethodCalledOnElementFailsOnTest/shouldCondition_WhenInnerElementFromOuterElementFoundByIndexInFilteredCollection_WithNonExistentInnerElement/1471825188045.0.png
+            Timeout: 0 ms.
+            Caused by: NoSuchElementException: Unable to locate element: {"method":"css selector","selector":".nonexistent"}
+        */
+    }
+
+
+}

--- a/src/test/java/integration/errormessages/MethodCalledOnElementPassesOnTest.java
+++ b/src/test/java/integration/errormessages/MethodCalledOnElementPassesOnTest.java
@@ -1,0 +1,115 @@
+package integration.errormessages;
+
+import com.codeborne.selenide.Configuration;
+import com.codeborne.selenide.SelenideElement;
+import integration.IntegrationTest;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.codeborne.selenide.Condition.*;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.$$;
+import static integration.helpers.HTMLBuilderForTestPreconditions.Given;
+import static org.junit.Assert.*;
+
+public class MethodCalledOnElementPassesOnTest extends IntegrationTest {
+
+    @Before
+    public void openPage() {
+        Given.openedPageWithBody(
+                "<ul>Hello to:",
+                "<li class='the-expanse detective'>Miller <label>detective</label></li>",
+                "<li class='the-expanse missing'>Julie Mao</li>",
+                "</ul>"
+        );
+        Configuration.timeout = 0;
+    }
+
+    @Test
+    public void shouldCondition_When$Element() {
+        SelenideElement element = $("ul li");
+
+        element.shouldHave(text("Miller"));
+    }
+
+    @Test
+    public void actionWithoutWaiting__When$Element() {
+        SelenideElement element = $("ul li");
+
+        assertTrue(element.isDisplayed());
+    }
+
+    @Test
+    public void actionWithoutWaiting_When$Element_WithNonExistentWebElement() {
+        SelenideElement element = $("ul .nonexistent");
+
+        assertFalse(element.exists());
+    }
+
+    @Test
+    public void shouldCondition_WhenCollectionElementByIndex() {
+        SelenideElement element = $$("ul li").get(0);
+
+        element.shouldHave(text("Miller"));
+    }
+
+    @Test
+    public void actionWithVisibilityWaiting_WhenCollectionElementByIndex() {
+        SelenideElement element = $$("ul li").get(0);
+
+        element.click();
+    }
+
+    @Test
+    public void shouldCondition_WhenCollectionElementByCondition() {
+        SelenideElement element = $$("li").findBy(cssClass("the-expanse"));
+
+        element.shouldBe(visible);
+    }
+
+    @Test
+    public void actionWithExistenceWaiting_WhenCollectionElementByCondition() {
+        SelenideElement element = $$("li").findBy(cssClass("the-expanse"));
+
+        assertEquals("Miller detective", element.text());
+    }
+
+    @Test
+    public void shouldCondition_WhenInnerElement() {
+        SelenideElement element = $("ul").find(".the-expanse");
+
+        element.shouldBe(visible);
+    }
+
+    @Test
+    public void actionWithVisibilityWaiting_WhenInnerElement() {
+        SelenideElement element = $("ul").find(".the-expanse");
+
+        element.doubleClick();
+    }
+
+    /******************************************************
+     * More complicated useful options
+     * $$.filterBy(condition).findBy(condition).find
+     ******************************************************/
+
+    @Test
+    public void shouldCondition_WhenInnerElementFromOuterElementByConditionInFilteredCollection() {
+        SelenideElement element = $$("ul li").filterBy(cssClass("the-expanse")).findBy(cssClass("detective")).find("label");
+
+        element.shouldHave(exactText("detective"));
+    }
+
+    /******************************************************
+     * More complicated useful options
+     * $$.filterBy(condition).get(index).find
+     ******************************************************/
+    @Test
+    public void shouldCondition_WhenInnerElementFromOuterElementFoundByIndexInFilteredCollection() {
+        SelenideElement element = $$("ul li").filterBy(cssClass("the-expanse")).get(0).find("label");
+
+        element.shouldHave(exactText("detective"));
+    }
+
+
+}

--- a/src/test/java/integration/errormessages/MethodCalledOnEntityWithInvalidLocatorFailsOnTest.java
+++ b/src/test/java/integration/errormessages/MethodCalledOnEntityWithInvalidLocatorFailsOnTest.java
@@ -7,6 +7,7 @@ import com.codeborne.selenide.ex.ElementNotFound;
 import integration.IntegrationTest;
 import integration.helpers.HTMLBuilderForTestPreconditions;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.InvalidSelectorException;
 
@@ -18,6 +19,7 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
+@Ignore
 public class MethodCalledOnEntityWithInvalidLocatorFailsOnTest extends IntegrationTest {
 
     @Before

--- a/src/test/java/integration/errormessages/MethodCalledOnEntityWithInvalidLocatorFailsOnTest.java
+++ b/src/test/java/integration/errormessages/MethodCalledOnEntityWithInvalidLocatorFailsOnTest.java
@@ -1,0 +1,360 @@
+package integration.errormessages;
+
+import com.codeborne.selenide.Configuration;
+import com.codeborne.selenide.ElementsCollection;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.ex.ElementNotFound;
+import integration.IntegrationTest;
+import integration.helpers.HTMLBuilderForTestPreconditions;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.InvalidSelectorException;
+
+import static com.codeborne.selenide.CollectionCondition.exactTexts;
+import static com.codeborne.selenide.Condition.*;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.$$;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+
+public class MethodCalledOnEntityWithInvalidLocatorFailsOnTest extends IntegrationTest {
+
+    @Before
+    public void openPage() {
+        HTMLBuilderForTestPreconditions.Given.openedPageWithBody(
+                "<ul>Hello to:",
+                "<li class='the-expanse detective'>Miller <label>detective</label></li>",
+                "<li class='the-expanse missing'>Julie Mao</li>",
+                "</ul>"
+        );
+        Configuration.timeout = 0;
+    }
+
+    @Test
+    public void shouldCondition_When$Element_WithInvalidLocator() {
+        SelenideElement element = $("##invalid-locator");
+
+        try {
+            element.shouldHave(text("Miller"));
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {##invalid-locator}"));
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(InvalidSelectorException.class));
+            assertThat(expected.getCause().getMessage(),
+                    startsWith("The given selector ##invalid-locator is either invalid or does not result in a WebElement. The following error occurred:\n" +
+                            "InvalidSelectorError: An invalid or illegal selector was specified"));
+        }
+        //todo - need to fix
+        /*
+            org.openqa.selenium.InvalidSelectorException: The given selector ##invalid-locator is either invalid or does not result in a WebElement. The following error occurred:
+            InvalidSelectorError: An invalid or illegal selector was specified
+            Command duration or timeout: 76 milliseconds
+            For documentation on this error, please visit: http://seleniumhq.org/exceptions/invalid_selector_exception.html
+            Build info: version: '2.53.1', revision: 'a36b8b1cd5757287168e54b817830adce9b0158d', time: '2016-06-30 19:26:09'
+            System info: host: 'hp470g0', ip: '192.168.56.1', os.name: 'Windows 8.1', os.arch: 'x86', os.version: '6.3', java.version: '1.8.0_45'
+            Driver info: org.openqa.selenium.firefox.FirefoxDriver
+            Capabilities [{applicationCacheEnabled=true, rotatable=false, pageLoadStrategy=normal, handlesAlerts=true, databaseEnabled=true, version=46.0.1, platform=WINDOWS, nativeEvents=false, acceptSslCerts=true, webStorageEnabled=true, locationContextEnabled=true, browserName=firefox, takesScreenshot=true, javascriptEnabled=true, pageLoadingStrategy=normal, cssSelectorsEnabled=true}]
+            Session ID: 696cd371-d06e-4b8d-bd9c-0883f70dd1e4
+            *** Element info: {Using=css selector, value=##invalid-locator}
+        */
+    }
+
+    @Test
+    public void actionWithoutWaiting_When$Element__WithInvalidLocator() {
+        SelenideElement element = $("##invalid-locator");
+
+        try {
+            element.exists();
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {##invalid-locator}"));
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(InvalidSelectorException.class));
+            assertThat(expected.getCause().getMessage(),
+                    startsWith("The given selector ##invalid-locator is either invalid or does not result in a WebElement. The following error occurred:\n" +
+                            "InvalidSelectorError: An invalid or illegal selector was specified"));
+        }
+        //todo - need to fix
+        /*
+            org.openqa.selenium.InvalidSelectorException: The given selector ##invalid-locator is either invalid or does not result in a WebElement. The following error occurred:
+            InvalidSelectorError: An invalid or illegal selector was specified
+            Command duration or timeout: 52 milliseconds
+            For documentation on this error, please visit: http://seleniumhq.org/exceptions/invalid_selector_exception.html
+            Build info: version: '2.53.1', revision: 'a36b8b1cd5757287168e54b817830adce9b0158d', time: '2016-06-30 19:26:09'
+            System info: host: 'hp470g0', ip: '192.168.56.1', os.name: 'Windows 8.1', os.arch: 'x86', os.version: '6.3', java.version: '1.8.0_45'
+            Driver info: org.openqa.selenium.firefox.FirefoxDriver
+            Capabilities [{applicationCacheEnabled=true, rotatable=false, pageLoadStrategy=normal, handlesAlerts=true, databaseEnabled=true, version=46.0.1, platform=WINDOWS, nativeEvents=false, acceptSslCerts=true, webStorageEnabled=true, locationContextEnabled=true, browserName=firefox, takesScreenshot=true, javascriptEnabled=true, pageLoadingStrategy=normal, cssSelectorsEnabled=true}]
+            Session ID: f69f7320-9d8b-45b5-a5c7-719ab7749558
+            *** Element info: {Using=css selector, value=##invalid-locator}
+        */
+
+    }
+
+    @Test
+    public void shouldCondition_WhenCollectionElementByIndex_WithInvalidCollectionLocator() {
+        SelenideElement element = $$("##invalid-locator").get(0);
+
+        try {
+            element.shouldHave(text("Miller"));
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {##invalid-locator}"));
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(InvalidSelectorException.class));
+            assertThat(expected.getCause().getMessage(),
+                    startsWith("The given selector ##invalid-locator is either invalid or does not result in a WebElement. The following error occurred:\n" +
+                            "InvalidSelectorError: An invalid or illegal selector was specified"));
+        }
+        //todo - need to fix
+        /*
+            org.openqa.selenium.InvalidSelectorException: The given selector ##invalid-locator is either invalid or does not result in a WebElement. The following error occurred:
+            InvalidSelectorError: An invalid or illegal selector was specified
+            Command duration or timeout: 63 milliseconds
+            For documentation on this error, please visit: http://seleniumhq.org/exceptions/invalid_selector_exception.html
+            Build info: version: '2.53.1', revision: 'a36b8b1cd5757287168e54b817830adce9b0158d', time: '2016-06-30 19:26:09'
+            System info: host: 'hp470g0', ip: '192.168.56.1', os.name: 'Windows 8.1', os.arch: 'x86', os.version: '6.3', java.version: '1.8.0_45'
+            Driver info: org.openqa.selenium.firefox.FirefoxDriver
+            Capabilities [{applicationCacheEnabled=true, rotatable=false, pageLoadStrategy=normal, handlesAlerts=true, databaseEnabled=true, version=46.0.1, platform=WINDOWS, nativeEvents=false, acceptSslCerts=true, webStorageEnabled=true, locationContextEnabled=true, browserName=firefox, takesScreenshot=true, javascriptEnabled=true, pageLoadingStrategy=normal, cssSelectorsEnabled=true}]
+            Session ID: 257857cd-c69d-419d-99c6-6bf7ee2648af
+            *** Element info: {Using=css selector, value=##invalid-locator}
+        */
+    }
+
+    @Test
+    public void shouldCondition_WhenCollectionElementByCondition_WithInvalidCollectionLocator() {
+        SelenideElement element = $$("##invalid-locator").findBy(cssClass("the-expanse"));
+
+        try {
+            element.shouldBe(present);
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {##invalid-locator}"));
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(InvalidSelectorException.class));
+            assertThat(expected.getCause().getMessage(),
+                    startsWith("The given selector ##invalid-locator is either invalid or does not result in a WebElement. The following error occurred:\n" +
+                            "InvalidSelectorError: An invalid or illegal selector was specified"));
+        }
+        //todo  - need to fix
+        /*
+            org.openqa.selenium.InvalidSelectorException: The given selector ##invalid-locator is either invalid or does not result in a WebElement. The following error occurred:
+            InvalidSelectorError: An invalid or illegal selector was specified
+            Command duration or timeout: 54 milliseconds
+            For documentation on this error, please visit: http://seleniumhq.org/exceptions/invalid_selector_exception.html
+            Build info: version: '2.53.1', revision: 'a36b8b1cd5757287168e54b817830adce9b0158d', time: '2016-06-30 19:26:09'
+            System info: host: 'hp470g0', ip: '192.168.56.1', os.name: 'Windows 8.1', os.arch: 'x86', os.version: '6.3', java.version: '1.8.0_45'
+            Driver info: org.openqa.selenium.firefox.FirefoxDriver
+            Capabilities [{applicationCacheEnabled=true, rotatable=false, pageLoadStrategy=normal, handlesAlerts=true, databaseEnabled=true, version=46.0.1, platform=WINDOWS, nativeEvents=false, acceptSslCerts=true, webStorageEnabled=true, locationContextEnabled=true, browserName=firefox, takesScreenshot=true, javascriptEnabled=true, pageLoadingStrategy=normal, cssSelectorsEnabled=true}]
+            Session ID: 1d0f1457-cbd4-45b3-b796-8d93c052bb1c
+            *** Element info: {Using=css selector, value=##invalid-locator}
+        */
+    }
+
+    @Test
+    public void shouldCondition_WhenInnerElement_WithInvalidInnerElementLocator() {
+        SelenideElement element = $("ul").find("##invalid-locator");
+
+        try {
+            element.shouldBe(present);
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {##invalid-locator}"));
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(InvalidSelectorException.class));
+            assertThat(expected.getCause().getMessage(),
+                    startsWith("The given selector ##invalid-locator is either invalid or does not result in a WebElement. The following error occurred:\n" +
+                            "InvalidSelectorError: An invalid or illegal selector was specified"));
+
+        }
+        //todo  - need to fix
+        /*
+            org.openqa.selenium.InvalidSelectorException: The given selector ##invalid-locator is either invalid or does not result in a WebElement. The following error occurred:
+            InvalidSelectorError: An invalid or illegal selector was specified
+            Command duration or timeout: 58 milliseconds
+            For documentation on this error, please visit: http://seleniumhq.org/exceptions/invalid_selector_exception.html
+            Build info: version: '2.53.1', revision: 'a36b8b1cd5757287168e54b817830adce9b0158d', time: '2016-06-30 19:26:09'
+            System info: host: 'hp470g0', ip: '192.168.56.1', os.name: 'Windows 8.1', os.arch: 'x86', os.version: '6.3', java.version: '1.8.0_45'
+            Driver info: org.openqa.selenium.firefox.FirefoxDriver
+            Capabilities [{applicationCacheEnabled=true, rotatable=false, pageLoadStrategy=normal, handlesAlerts=true, databaseEnabled=true, version=46.0.1, platform=WINDOWS, nativeEvents=false, acceptSslCerts=true, webStorageEnabled=true, locationContextEnabled=true, browserName=firefox, takesScreenshot=true, javascriptEnabled=true, pageLoadingStrategy=normal, cssSelectorsEnabled=true}]
+            Session ID: 86fcc23f-66f6-40fe-9d2f-78c2b5fc07bd
+            *** Element info: {Using=css selector, value=##invalid-locator}
+        */
+    }
+
+    @Test
+    public void shouldCondition_WhenInnerElement_WithInvalidOuterElementLocator() {
+        SelenideElement element = $("##invalid-locator").find(".the-expanse");
+
+        try {
+            element.shouldBe(exactTextCaseSensitive("Miller"));
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            assertThat(expected.getMessage(), startsWith("Element not found {##invalid-locator}"));
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(InvalidSelectorException.class));
+            assertThat(expected.getCause().getMessage(),
+                    startsWith("The given selector ##invalid-locator is either invalid or does not result in a WebElement. The following error occurred:\n" +
+                            "InvalidSelectorError: An invalid or illegal selector was specified"));
+        }
+        //todo  - need to fix
+        /*
+            org.openqa.selenium.InvalidSelectorException: The given selector ##invalid-locator is either invalid or does not result in a WebElement. The following error occurred:
+            InvalidSelectorError: An invalid or illegal selector was specified
+            Command duration or timeout: 81 milliseconds
+            For documentation on this error, please visit: http://seleniumhq.org/exceptions/invalid_selector_exception.html
+            Build info: version: '2.53.1', revision: 'a36b8b1cd5757287168e54b817830adce9b0158d', time: '2016-06-30 19:26:09'
+            System info: host: 'hp470g0', ip: '192.168.56.1', os.name: 'Windows 8.1', os.arch: 'x86', os.version: '6.3', java.version: '1.8.0_45'
+            Driver info: org.openqa.selenium.firefox.FirefoxDriver
+            Capabilities [{applicationCacheEnabled=true, rotatable=false, pageLoadStrategy=normal, handlesAlerts=true, databaseEnabled=true, version=46.0.1, platform=WINDOWS, nativeEvents=false, acceptSslCerts=true, webStorageEnabled=true, locationContextEnabled=true, browserName=firefox, takesScreenshot=true, javascriptEnabled=true, pageLoadingStrategy=normal, cssSelectorsEnabled=true}]
+            Session ID: b0422c41-203b-431d-ae76-9104adb588d5
+            *** Element info: {Using=css selector, value=##invalid-locator}
+        */
+    }
+
+    @Test
+    public void shouldCondition_When$$Collection_WithInvalidLocator() {
+        ElementsCollection collection = $$("##invalid-locator");
+
+        try {
+            collection.shouldHave(exactTexts("Miller", "Julie Mao"));
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            //todo - need to fix
+            assertThat(expected.getMessage(), startsWith("Element not found {##invalid-locator}"));
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(InvalidSelectorException.class));
+            assertThat(expected.getCause().getMessage(),
+                    startsWith("The given selector ##invalid-locator is either invalid or does not result in a WebElement. The following error occurred:\n" +
+                            "InvalidSelectorError: An invalid or illegal selector was specified\n"));
+        }
+        /*
+            org.openqa.selenium.InvalidSelectorException: The given selector ##invalid-locator is either invalid or does not result in a WebElement. The following error occurred:
+            InvalidSelectorError: An invalid or illegal selector was specified
+            Command duration or timeout: 53 milliseconds
+            For documentation on this error, please visit: http://seleniumhq.org/exceptions/invalid_selector_exception.html
+            Build info: version: '2.53.1', revision: 'a36b8b1cd5757287168e54b817830adce9b0158d', time: '2016-06-30 19:26:09'
+            System info: host: 'hp470g0', ip: '192.168.56.1', os.name: 'Windows 8.1', os.arch: 'x86', os.version: '6.3', java.version: '1.8.0_45'
+            Driver info: org.openqa.selenium.firefox.FirefoxDriver
+            Capabilities [{applicationCacheEnabled=true, rotatable=false, pageLoadStrategy=normal, handlesAlerts=true, databaseEnabled=true, version=46.0.1, platform=WINDOWS, nativeEvents=false, acceptSslCerts=true, webStorageEnabled=true, locationContextEnabled=true, browserName=firefox, takesScreenshot=true, javascriptEnabled=true, pageLoadingStrategy=normal, cssSelectorsEnabled=true}]
+            Session ID: b6e66fca-fc9e-48dd-9103-0f7086859ddf
+            *** Element info: {Using=css selector, value=##invalid-locator}
+        */
+    }
+
+    @Test
+    public void actionWithoutWaiting_WhenFilteredCollection_WithInvalidLocator() {
+        ElementsCollection collection = $$("##invalid-locator").filter(cssClass("the-expanse"));
+
+        try {
+            collection.getTexts();
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            //todo - need to fix
+            assertThat(expected.getMessage(), startsWith("Element not found {##invalid-locator}"));
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(InvalidSelectorException.class));
+            assertThat(expected.getCause().getMessage(),
+                    startsWith("The given selector ##invalid-locator is either invalid or does not result in a WebElement. The following error occurred:\n" +
+                            "InvalidSelectorError: An invalid or illegal selector was specified\n"));
+        }
+        /*
+            org.openqa.selenium.InvalidSelectorException: The given selector ##invalid-locator is either invalid or does not result in a WebElement. The following error occurred:
+            InvalidSelectorError: An invalid or illegal selector was specified
+            Command duration or timeout: 224 milliseconds
+            For documentation on this error, please visit: http://seleniumhq.org/exceptions/invalid_selector_exception.html
+            Build info: version: '2.53.1', revision: 'a36b8b1cd5757287168e54b817830adce9b0158d', time: '2016-06-30 19:26:09'
+            System info: host: 'hp470g0', ip: '192.168.56.1', os.name: 'Windows 8.1', os.arch: 'x86', os.version: '6.3', java.version: '1.8.0_45'
+            Driver info: org.openqa.selenium.firefox.FirefoxDriver
+            Capabilities [{applicationCacheEnabled=true, rotatable=false, pageLoadStrategy=normal, handlesAlerts=true, databaseEnabled=true, version=46.0.1, platform=WINDOWS, nativeEvents=false, acceptSslCerts=true, webStorageEnabled=true, locationContextEnabled=true, browserName=firefox, takesScreenshot=true, javascriptEnabled=true, pageLoadingStrategy=normal, cssSelectorsEnabled=true}]
+            Session ID: 7bbda627-bbb5-4cc3-a60e-d06f10babc2c
+            *** Element info: {Using=css selector, value=##invalid-locator}
+        */
+    }
+
+    @Test
+    public void shouldCondition_WhenFilteredCollection_WithInvalidLocator() {
+        ElementsCollection collection = $$("##invalid-locator").filter(cssClass("the-expanse"));
+
+        try {
+            collection.shouldHave(exactTexts("Miller", "Julie Mao"));
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            //todo - need to fix
+            assertThat(expected.getMessage(), startsWith("Element not found {##invalid-locator}"));
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(InvalidSelectorException.class));
+            assertThat(expected.getCause().getMessage(),
+                    startsWith("The given selector ##invalid-locator is either invalid or does not result in a WebElement. The following error occurred:\n" +
+                            "InvalidSelectorError: An invalid or illegal selector was specified\n"));
+        }
+        /*
+            org.openqa.selenium.InvalidSelectorException: The given selector ##invalid-locator is either invalid or does not result in a WebElement. The following error occurred:
+            InvalidSelectorError: An invalid or illegal selector was specified
+            Command duration or timeout: 62 milliseconds
+            For documentation on this error, please visit: http://seleniumhq.org/exceptions/invalid_selector_exception.html
+            Build info: version: '2.53.1', revision: 'a36b8b1cd5757287168e54b817830adce9b0158d', time: '2016-06-30 19:26:09'
+            System info: host: 'hp470g0', ip: '192.168.56.1', os.name: 'Windows 8.1', os.arch: 'x86', os.version: '6.3', java.version: '1.8.0_45'
+            Driver info: org.openqa.selenium.firefox.FirefoxDriver
+            Capabilities [{applicationCacheEnabled=true, rotatable=false, pageLoadStrategy=normal, handlesAlerts=true, databaseEnabled=true, version=46.0.1, platform=WINDOWS, nativeEvents=false, acceptSslCerts=true, webStorageEnabled=true, locationContextEnabled=true, browserName=firefox, takesScreenshot=true, javascriptEnabled=true, pageLoadingStrategy=normal, cssSelectorsEnabled=true}]
+            Session ID: efae40e6-44e8-4a2d-9987-80f6a54852c3
+            *** Element info: {Using=css selector, value=##invalid-locator}
+        */
+    }
+
+    @Test
+    public void shouldCondition_WhenInnerCollection_WithOuterInvalidLocator() {
+        ElementsCollection collection = $("##invalid-locator").findAll("li");
+
+        try {
+            collection.shouldHave(exactTexts("Miller", "Julie Mao"));
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            //todo - need to fix
+            assertThat(expected.getMessage(), startsWith("Element not found {##invalid-locator}"));
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(InvalidSelectorException.class));
+            assertThat(expected.getCause().getMessage(),
+                    startsWith("The given selector ##invalid-locator is either invalid or does not result in a WebElement. The following error occurred:\n" +
+                            "InvalidSelectorError: An invalid or illegal selector was specified\n"));
+        }
+        /*
+            org.openqa.selenium.InvalidSelectorException: The given selector ##invalid-locator is either invalid or does not result in a WebElement. The following error occurred:
+            InvalidSelectorError: An invalid or illegal selector was specified
+            Command duration or timeout: 250 milliseconds
+            For documentation on this error, please visit: http://seleniumhq.org/exceptions/invalid_selector_exception.html
+            Build info: version: '2.53.1', revision: 'a36b8b1cd5757287168e54b817830adce9b0158d', time: '2016-06-30 19:26:09'
+            System info: host: 'hp470g0', ip: '192.168.56.1', os.name: 'Windows 8.1', os.arch: 'x86', os.version: '6.3', java.version: '1.8.0_45'
+            Driver info: org.openqa.selenium.firefox.FirefoxDriver
+            Capabilities [{applicationCacheEnabled=true, rotatable=false, pageLoadStrategy=normal, handlesAlerts=true, databaseEnabled=true, version=44.0, platform=WINDOWS, nativeEvents=false, acceptSslCerts=true, webStorageEnabled=true, locationContextEnabled=true, browserName=firefox, takesScreenshot=true, javascriptEnabled=true, pageLoadingStrategy=normal, cssSelectorsEnabled=true}]
+            Session ID: 5c78bba8-1c4d-4319-b9fb-710b9310ecc5
+            *** Element info: {Using=css selector, value=##invalid-locator}
+        */
+    }
+
+    @Test
+    public void shouldCondition_WhenInnerCollection_WithInnerInvalidLocator() {
+        ElementsCollection collection = $("ul").findAll("##invalid-locator");
+
+        try {
+            collection.shouldHave(exactTexts("Miller", "Julie Mao"));
+            fail("Expected ElementNotFound");
+        } catch (ElementNotFound expected) {
+            //todo - need to fix
+            assertThat(expected.getMessage(), startsWith("Element not found {ul}"));
+            assertThat(expected.getScreenshot(), containsString(Configuration.reportsFolder));
+            assertThat(expected.getCause(), instanceOf(InvalidSelectorException.class));
+            assertThat(expected.getCause().getMessage(), containsString("##invalid-locator"));
+        }
+        /*
+            Element not found {ul}
+            Expected: exist
+
+            Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration/errormessages/MethodCalledOnEntityWithInvalidLocatorFailsOnTest/shouldCondition_WhenInnerCollection_WithInnerInvalidLocator/1471820076618.1.png
+            Timeout: 6 s.
+            Caused by: NoSuchElementException: Unable to locate element: {"method":"css selector","selector":"ul"}
+        */
+    }
+
+}

--- a/src/test/java/integration/errormessages/package-info.java
+++ b/src/test/java/integration/errormessages/package-info.java
@@ -1,0 +1,62 @@
+/*
+* Tests for getting element / collection in different way
+* if element / collection is not found or does not exist
+* exception and its message should be appropriate and enough verbose to understand cause of error
+*
+* tests
+*      collection
+*                get entity
+*                          $$
+*                          $$.filter
+*                          $.findAll
+*                actions
+*                       with wait
+*                                should(condition)
+*                       without wait
+*                                   getTexts()
+*                                   size()
+*                                   isEmpty()
+*      element
+*             get entity
+*                       $
+*                       $$.get(index)
+*                       $$.findBy(condition)
+*                       $.find
+*                       more complicated & useful enough
+*                                                       $$.filterBy(condition).findBy(condition).find
+*                                                       $$.filterBy(condition).get(index).find
+*             actions
+*                    with wait
+*                             should(condition)
+*                             visibility
+*                                       click()
+*                                       doubleclick()
+*                                       ...
+*                             existence in DOM
+*                                             getValue()
+*                                             text()
+*                                             innerText()
+*                                             ...
+*                    without waiting
+*                                   isDisplayed()
+*                                   exist()
+*
+*  fail options
+*             fail on getting element / elements
+*             nonexistent WebElement / WebElements
+*             invalid locator
+*             IndexOutOfRange
+*             not satisfied condition
+*
+* fail on should (todo - after a decision about correct error & caused by error - asserts fix needed)
+*                (comment at MethodCalledOnCollectionFailsOnTest: todo - hypothesis - error should be according to condition plus caused by ElementNotFound )
+*
+* additional tests (todo - one test per each option with condition usage)
+* conditions rendering
+*                     not(condition)
+*                     and(name, conditions)
+*                     or(name, conditions)
+*
+*/
+
+package integration.errormessages;

--- a/src/test/java/integration/helpers/HTMLBuilderForTestPreconditions.java
+++ b/src/test/java/integration/helpers/HTMLBuilderForTestPreconditions.java
@@ -1,0 +1,66 @@
+package integration.helpers;
+
+import static com.codeborne.selenide.Selenide.executeJavaScript;
+import static com.codeborne.selenide.Selenide.open;
+
+public class HTMLBuilderForTestPreconditions {
+
+
+    private static void execute(String jsCommand) {
+        executeJavaScript(jsCommand);
+    }
+
+    public static class When {
+
+        public static void withBody(String... html) {
+            execute(
+                    String.join(" ",
+                            "document.getElementsByTagName('body')[0].innerHTML =",
+                            "\"",
+                            String.join(" ", html).replace("\n", " "),
+                            "\";"
+                    )
+            );
+        }
+
+        public static void withBodyTimedOut(int timeout, String... html) {
+            execute(
+                    String.join(" ",
+                            "setTimeout(",
+                            "function(){",
+                            "document.getElementsByTagName('body')[0].innerHTML = \"",
+                            String.join(" ", html).replace("\n", " "),
+                            "\" },",
+                            timeout + ");"
+                    )
+            );
+        }
+
+        public static void executeScriptWithTimeout(int timeout, String... js) {
+            execute(
+                    String.join(" ",
+                            "setTimeout(",
+                            "function(){",
+                            String.join(" ", js),
+                            "},",
+                            timeout + ");"
+                    )
+            );
+        }
+
+    }
+
+    public static class Given {
+
+        public static void openedEmptyPage() {
+            open("/empty.html");
+        }
+
+        public static void openedPageWithBody(String... html) {
+            Given.openedEmptyPage();
+            When.withBody(html);
+        }
+
+    }
+
+}

--- a/src/test/java/integration/helpers/package-info.java
+++ b/src/test/java/integration/helpers/package-info.java
@@ -1,0 +1,17 @@
+/*
+*   This package contains useful helpers for integration tests
+*   HtmlBuilderForGivens
+*       contains tools to build some html page in given actions
+*           example
+*                Given.openedPageWithBody(
+*                        "<h2 id='second'>Heading 2</h2>"
+*                        );
+*                When.withBodyTimedOut(250,
+*                        "<a href='#second' style='display:none'>go to Heading 2</a>",
+*                        "<h2 id='second'>Heading 2</h2>"
+*                        );
+*                When.executeScriptWithTimeout(500,
+*                        "document.getElementsByTagName('a')[0].style = 'display:block';"
+*                        );
+*/
+package integration.helpers;

--- a/src/test/resources/empty.html
+++ b/src/test/resources/empty.html
@@ -1,0 +1,10 @@
+<html>
+
+<head>
+    <title>start page</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+</head>
+<body>
+<!--<h2>Start page</h2>-->
+</body>
+</html>


### PR DESCRIPTION
#243, #365 
- selenide/ElementsCollection#find changed 
- selenide/impl/CollectionElementByCondition - added (used in ElementsCollection#find)
- selenide/impl/WebElementSource#checkCondition - changed (used Throwable instead of RuntimeException)
    - it was needed to catch IndexOutOfBounds, which throwed from ElementsCollection code
    - now ElementsCollection#findBy throws ElementNotFound error in case of element is not found

test/java/integration/ScreenshotTest#canTakeScreenshotOfElement() - changed (failed on windows)

Given helpers - html site building. Added:
- src/test/java/integration/helpers
- src/test/resources/empty.html

Test classes - getting collections & elements in different way and error messages assertion
- src/test/java/integration/errormessages - test classes added (MethodCalledOnEntityWithInvalidLocatorFailsOnTest - failing tests)
- src/test/java/integration/errormessages/package-info.java - description added
- in test methods it is included:
   - real error message
   - our questions (marked as todo)


 
