### PR TITLE
Making Element column size in Text Report dynamic

### DIFF
--- a/src/main/java/com/codeborne/selenide/logevents/SimpleReport.java
+++ b/src/main/java/com/codeborne/selenide/logevents/SimpleReport.java
@@ -3,6 +3,7 @@ package com.codeborne.selenide.logevents;
 import com.google.common.base.Joiner;
 
 import java.util.Collections;
+import java.util.OptionalInt;
 import java.util.logging.Logger;
 
 /**
@@ -20,17 +21,26 @@ public class SimpleReport {
   public void finish(String title) {
     EventsCollector logEventListener = SelenideLogger.removeListener("simpleReport");
 
+    OptionalInt maxLineLength = logEventListener.events()
+            .stream()
+            .map(LogEvent::getElement)
+            .map(String::length)
+            .mapToInt(Integer::intValue)
+            .max();
+
+    int count = maxLineLength.orElse(0) >= 20 ? (maxLineLength.getAsInt() + 1): 20;
+
     StringBuilder sb = new StringBuilder();
     sb.append("Report for ").append(title).append('\n');
 
-    String delimiter = '+' + Joiner.on('+').join(line(20), line(70), line(10), line(10)) + "+\n";
+    String delimiter = '+' + Joiner.on('+').join(line(count), line(70), line(10), line(10)) + "+\n";
 
     sb.append(delimiter);
-    sb.append(String.format("|%-20s|%-70s|%-10s|%-10s|%n", "Element", "Subject", "Status", "ms."));
+    sb.append(String.format("|%-" + count + "s|%-70s|%-10s|%-10s|%n", "Element", "Subject", "Status", "ms."));
     sb.append(delimiter);
 
     for (LogEvent e : logEventListener.events()) {
-      sb.append(String.format("|%-20s|%-70s|%-10s|%-10s|%n", e.getElement(), e.getSubject(),
+      sb.append(String.format("|%-" + count + "s|%-70s|%-10s|%-10s|%n", e.getElement(), e.getSubject(),
               e.getStatus(), e.getDuration()));
     }
     sb.append(delimiter);

--- a/src/main/java/com/codeborne/selenide/logevents/SimpleReport.java
+++ b/src/main/java/com/codeborne/selenide/logevents/SimpleReport.java
@@ -28,7 +28,7 @@ public class SimpleReport {
             .mapToInt(Integer::intValue)
             .max();
 
-    int count = maxLineLength.orElse(0) >= 20 ? (maxLineLength.getAsInt() + 1): 20;
+    int count = maxLineLength.orElse(0) >= 20 ? (maxLineLength.getAsInt() + 1) : 20;
 
     StringBuilder sb = new StringBuilder();
     sb.append("Report for ").append(title).append('\n');


### PR DESCRIPTION
By default the size of Element column in text report is 20 characters. If there is an element which length is bigger than 20 chars(e.g. By.xpath: ./[@class='rc']/h3/a) the text report gets messed up:
<a href="http://www.imagebam.com/image/760ad3518848859" target="_blank"><img src="http://thumbnails115.imagebam.com/51885/760ad3518848859.jpg" alt="imagebam.com"></a>

My changes making the Element column size dynamic, based on the element length. If the length is less than 20, the column will have the default size of 20. If the length is greater or equals than 20, then the Element column size will be equal to element length + 1 (the +1 is needed to separate it from the | delimiter). 
So the report will look like this:
<a href="http://www.imagebam.com/image/f9b2a5518848851" target="_blank"><img src="http://thumbnails115.imagebam.com/51885/f9b2a5518848851.jpg" alt="imagebam.com"></a>