### PR TITLE
Upload test results report from Travice CI to temporary storage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,5 @@ before_install:
 after_success:
 - ./gradle jacocoTestReport coveralls
 - bash <(curl -s https://codecov.io/bash)
+
+after_script: "./.upload_reports.sh"

--- a/.upload_reports.sh
+++ b/.upload_reports.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+HERE="`dirname \"$0\"`"				# relative
+HERE="`( cd \"$HERE\" && pwd )`" 	# absolutized and normalized
+if [ -z "$HERE" ] ; then
+	# error; for some reason, the path is not accessible
+	# to the script (e.g. permissions re-evaled after suid)
+	exit 1  # fail
+fi
+
+ARTIFACTS_DIR="${HERE}/build/reports/"
+ARTIFACTS_FILE=${TRAVIS_JOB_NUMBER}_log.tar.gz
+
+ls $ARTIFACTS_DIR
+echo "COMPRESSING build artifacts."
+cd $ARTIFACTS_DIR
+tar -zcvf $ARTIFACTS_FILE *
+# upload to http://transfer.sh
+echo "Uploading to transfer.sh"
+curl --upload-file $ARTIFACTS_FILE http://transfer.sh


### PR DESCRIPTION
I think it's hard to look for Travise build logs to find out which tests are failed.
This PR improves Travise CI configuration - now all files from 'build/reports/' will upload to http://transfer.sh. 
It will be easy to download and read reports.
