### PR TITLE
Selenide support for PageObjects without @FindBy annotations

### DIFF
--- a/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/src/main/java/com/codeborne/selenide/Selenide.java
@@ -568,7 +568,7 @@ public class Selenide {
    * @see PageFactory#initElements(WebDriver, Class)
    */
   public static <PageObjectClass, T extends PageObjectClass> PageObjectClass page(T pageObject) {
-    PageFactory.initElements(new SelenideFieldDecorator(getWebDriver()), pageObject);
+    SelenidePageFactory.initElements(new SelenideFieldDecorator(getWebDriver()), pageObject);
     return pageObject;
   }
 

--- a/src/main/java/com/codeborne/selenide/SelenidePageFactory.java
+++ b/src/main/java/com/codeborne/selenide/SelenidePageFactory.java
@@ -1,0 +1,48 @@
+package com.codeborne.selenide;
+
+import org.openqa.selenium.support.pagefactory.FieldDecorator;
+
+import java.lang.reflect.Field;
+
+/**
+ * Factory class to make using Page Objects simpler and easier.
+ *
+ * @see <a href="https://github.com/SeleniumHQ/selenium/wiki/PageObjects">Page Objects Wiki</a>
+ */
+public class SelenidePageFactory {
+
+    public static void initElements(FieldDecorator decorator, Object page) {
+        Class<?> proxyIn = page.getClass();
+        while (proxyIn != Object.class) {
+            proxyFields(decorator, page, proxyIn);
+            proxyIn = proxyIn.getSuperclass();
+        }
+    }
+
+    private static void proxyFields(FieldDecorator decorator, Object page, Class<?> proxyIn) {
+        Field[] fields = proxyIn.getDeclaredFields();
+        for (Field field : fields) {
+            if(isInitialized(page, field)){
+                continue;
+            }
+            Object value = decorator.decorate(page.getClass().getClassLoader(), field);
+            if (value != null) {
+                try {
+                    field.setAccessible(true);
+                    field.set(page, value);
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+
+    private static boolean isInitialized(Object page, Field field){
+        try {
+            field.setAccessible(true);
+            return field.get(page) != null;
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/integration/SelenidePageFactoryTest.java
+++ b/src/test/java/integration/SelenidePageFactoryTest.java
@@ -1,0 +1,45 @@
+package integration;
+
+import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.Configuration;
+import com.codeborne.selenide.SelenideElement;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.support.FindBy;
+
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.page;
+
+/**
+ * Created by sepi on 21.12.16.
+ */
+public class SelenidePageFactoryTest extends IntegrationTest{
+
+    @Before
+    public void openTestPage() {
+        openFile("start_page.html");
+    }
+
+    @Test
+    public void canInitPageWithFindByAnnotations(){
+        StartPageWithAnnotation startPage = page(StartPageWithAnnotation.class);
+        startPage.pageText.shouldHave(Condition.text("Start page"));
+    }
+
+    @Test
+    public void canInitPageWithoutFindByAnnotations(){
+        StartPageWithoutAnnotation startPage = page(StartPageWithoutAnnotation.class);
+        startPage.pageHeader.shouldHave(Condition.text("Selenide"));
+    }
+}
+
+class StartPageWithAnnotation {
+    @FindBy(css = "#start-selenide")
+    public SelenideElement pageText;
+}
+
+class StartPageWithoutAnnotation {
+    public SelenideElement pageHeader  = $("h1");
+}
+
+

--- a/src/test/java/integration/SelenidePageFactoryTest.java
+++ b/src/test/java/integration/SelenidePageFactoryTest.java
@@ -1,7 +1,6 @@
 package integration;
 
 import com.codeborne.selenide.Condition;
-import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.SelenideElement;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,33 +12,33 @@ import static com.codeborne.selenide.Selenide.page;
 /**
  * Created by sepi on 21.12.16.
  */
-public class SelenidePageFactoryTest extends IntegrationTest{
+public class SelenidePageFactoryTest extends IntegrationTest {
 
-    @Before
-    public void openTestPage() {
-        openFile("start_page.html");
-    }
+  @Before
+  public void openTestPage() {
+    openFile("start_page.html");
+  }
 
-    @Test
-    public void canInitPageWithFindByAnnotations(){
-        StartPageWithAnnotation startPage = page(StartPageWithAnnotation.class);
-        startPage.pageText.shouldHave(Condition.text("Start page"));
-    }
+  @Test
+  public void canInitPageWithFindByAnnotations() {
+    StartPageWithAnnotation startPage = page(StartPageWithAnnotation.class);
+    startPage.pageText.shouldHave(Condition.text("Start page"));
+  }
 
-    @Test
-    public void canInitPageWithoutFindByAnnotations(){
-        StartPageWithoutAnnotation startPage = page(StartPageWithoutAnnotation.class);
-        startPage.pageHeader.shouldHave(Condition.text("Selenide"));
-    }
+  @Test
+  public void canInitPageWithoutFindByAnnotations() {
+    StartPageWithoutAnnotation startPage = page(StartPageWithoutAnnotation.class);
+    startPage.pageHeader.shouldHave(Condition.text("Selenide"));
+  }
 }
 
 class StartPageWithAnnotation {
-    @FindBy(css = "#start-selenide")
-    public SelenideElement pageText;
+  @FindBy(css = "#start-selenide")
+  public SelenideElement pageText;
 }
 
 class StartPageWithoutAnnotation {
-    public SelenideElement pageHeader  = $("h1");
+  public SelenideElement pageHeader = $("h1");
 }
 
 


### PR DESCRIPTION
This PR fixes problem with initialization PageObjects that have SelenideElements declared as Class fields. See example below:

class StartPage{
     private SelenideElement startPage = $("#start-page");
}

Before fix, if we use Selenide methods open("url",Class) or page(class) Selenide ignored field initialization and tried to find element by ID or Name of class field. 