### PR TITLE
Added ability to set Capabilities and custom Firefox profile using Configuration.

### DIFF
--- a/src/main/java/com/codeborne/selenide/Configuration.java
+++ b/src/main/java/com/codeborne/selenide/Configuration.java
@@ -309,7 +309,7 @@ public class Configuration {
    * <b>Usage:</b><p>
    * DesiredCapabilities myCapabilities = new DesiredCapabilities();<p>
    * myCapabilities.setCapability("someCapability", "value");<p>
-   * Configuration.capabilities.set(myCapabilities)
+   * Configuration.capabilities.set(myCapabilities);
    */
   public static ThreadLocal<DesiredCapabilities> capabilities = new ThreadLocal<>();
 }

--- a/src/main/java/com/codeborne/selenide/Configuration.java
+++ b/src/main/java/com/codeborne/selenide/Configuration.java
@@ -1,5 +1,7 @@
 package com.codeborne.selenide;
 
+import org.openqa.selenium.remote.DesiredCapabilities;
+
 import java.util.logging.Logger;
 
 import static com.codeborne.selenide.Configuration.AssertionMode.STRICT;
@@ -300,4 +302,8 @@ public class Configuration {
 
   public static FileDownloadMode fileDownload = FileDownloadMode.valueOf(
       System.getProperty("selenide.fileDownload", HTTPGET.name()));
+
+
+
+  public static ThreadLocal<DesiredCapabilities> capabilities = new ThreadLocal<>();
 }

--- a/src/main/java/com/codeborne/selenide/Configuration.java
+++ b/src/main/java/com/codeborne/selenide/Configuration.java
@@ -304,6 +304,12 @@ public class Configuration {
       System.getProperty("selenide.fileDownload", HTTPGET.name()));
 
 
-
+  /**
+   * Sets additional WebDriver capabilities.<p>
+   * <b>Usage:</b><p>
+   * DesiredCapabilities myCapabilities = new DesiredCapabilities();<p>
+   * myCapabilities.setCapability("someCapability", "value");<p>
+   * Configuration.capabilities.set(myCapabilities)
+   */
   public static ThreadLocal<DesiredCapabilities> capabilities = new ThreadLocal<>();
 }

--- a/src/main/java/com/codeborne/selenide/webdriver/WebDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/WebDriverFactory.java
@@ -139,7 +139,16 @@ public class WebDriverFactory {
     myProfile.setPreference("security.csp.enable", false);
 
     DesiredCapabilities capabilities = createCommonCapabilities(proxy);
-    capabilities.setCapability(FirefoxDriver.PROFILE, myProfile);
+
+    boolean hasCustomProfile = false;
+    if (Configuration.capabilities.get() != null) {
+      hasCustomProfile = Configuration.capabilities.get().getCapability("firefox_profile") != null;
+    }
+
+    if (!hasCustomProfile) {
+      capabilities.setCapability(FirefoxDriver.PROFILE, myProfile);
+    }
+
     capabilities.setCapability("marionette", false);
     return capabilities;
   }

--- a/src/main/java/com/codeborne/selenide/webdriver/WebDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/WebDriverFactory.java
@@ -1,5 +1,6 @@
 package com.codeborne.selenide.webdriver;
 
+import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.WebDriverProvider;
 import org.openqa.selenium.Capabilities;
@@ -101,6 +102,11 @@ public class WebDriverFactory {
         browserCapabilities.setCapability(capability, value);
       }
     }
+
+    if (Configuration.capabilities.get() != null) {
+      browserCapabilities.merge(Configuration.capabilities.get());
+    }
+
     return browserCapabilities;
   }
   

--- a/src/test/java/com/codeborne/selenide/webdriver/WebDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/WebDriverFactoryTest.java
@@ -8,6 +8,7 @@ import org.openqa.selenium.Dimension;
 import org.openqa.selenium.Point;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.DesiredCapabilities;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -66,6 +67,20 @@ public class WebDriverFactoryTest {
     System.setProperty("capabilities.some.cap", "true");
     assertThat(factory.createCommonCapabilities(proxy).getCapability("some.cap"), is("true"));
 
+  }
+
+  @Test
+  public void transfersCapabilitiesFromConfigurationToDriver() {
+    DesiredCapabilities capabilities = new DesiredCapabilities();
+    capabilities.setCapability("testCapability1", true);
+    capabilities.setCapability("testCapability2", "false");
+    capabilities.setCapability("testCapability3", 1);
+
+    Configuration.capabilities.set(capabilities);
+
+    assertThat(factory.createCommonCapabilities(proxy).getCapability("testCapability1"), is(true));
+    assertThat(factory.createCommonCapabilities(proxy).getCapability("testCapability2"), is("false"));
+    assertThat(factory.createCommonCapabilities(proxy).getCapability("testCapability3"), is(1));
   }
 
   @After


### PR DESCRIPTION
As per this [request](https://github.com/codeborne/selenide/issues/444) I added the ability to set Desired Capabilities using Configuration class:
```
DesiredCapabilities myCapabilities = new DesiredCapabilities();
myCapabilities.setCapability("someCapability", "value");
Configuration.capabilities.set(myCapabilities); 
```
<br>
You can also add a custom profile to your capabilities:

```
FirefoxProfile profile = new FirefoxProfile();
profile.setPreference("intl.accept_languages", "de, en, en-us");
myCapabilities.setCapability(FirefoxDriver.PROFILE, profile);

```
<br>
This way your custom profile will override the default profile Selenide passes to the FirefoxDriver. If no profile is passed to the custom capabilities, the default Selenide profile will be used.