### PR TITLE
Adding customCommands support.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
 == Changelog
+=== 4.2.1 (Release in January 2017)
+* fixed problems with int and boolean capability values, now converting automatically
+* added support for FirefoxProfile over commandline (-Dfirefoxprofile.<option>=<value>,
+* added support for ChromeOptions (args only) over commandline (-Dchromeoptions.args=<value1>,<value2>...)
 
 === 4.2 (Released 13.12.2016)
 * #431 browser=firefox uses legacy driver (works for <=47), browser=marionette - gecko driver (any Firefox)

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -689,4 +689,15 @@ public interface SelenideElement extends WebElement, FindsByLinkText, FindsById,
    * @see com.codeborne.selenide.commands.TakeScreenshotAsImage
    */
   BufferedImage screenshotAsImage();
+
+  /**
+   * Execute registered custom command
+   *
+   * @param command name of registered custom command
+   * @param params parameters to pass to the registered custom command
+   * @return this element
+   *
+   * @see com.codeborne.selenide.commands.Commands
+   */
+  SelenideElement customCommand(String command, Object... params);
 }

--- a/src/main/java/com/codeborne/selenide/commands/Commands.java
+++ b/src/main/java/com/codeborne/selenide/commands/Commands.java
@@ -8,8 +8,6 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static java.util.Arrays.copyOfRange;
-
 public class Commands {
 
   private static final String CUSTOM_COMMAND = "customCommand";
@@ -150,8 +148,6 @@ public class Commands {
       throw new IllegalArgumentException("Unknown Selenide method: " + methodName);
     }
 
-    Object[] argsToForward = (CUSTOM_COMMAND.equals(methodName)) ? copyOfRange(args, 1, args.length) : args;
-
-    return (T) command.execute((SelenideElement) proxy, webElementSource, argsToForward);
+    return (T) command.execute((SelenideElement) proxy, webElementSource, CUSTOM_COMMAND.equals(methodName) ? (Object[]) args[1] : args);
   }
 }

--- a/src/main/java/com/codeborne/selenide/commands/Commands.java
+++ b/src/main/java/com/codeborne/selenide/commands/Commands.java
@@ -148,6 +148,7 @@ public class Commands {
       throw new IllegalArgumentException("Unknown Selenide method: " + methodName);
     }
 
-    return (T) command.execute((SelenideElement) proxy, webElementSource, CUSTOM_COMMAND.equals(methodName) ? (Object[]) args[1] : args);
+    Object[] argsToForward = CUSTOM_COMMAND.equals(methodName) ? (Object[]) args[1] : args;
+    return (T) command.execute((SelenideElement) proxy, webElementSource, argsToForward);
   }
 }

--- a/src/main/java/com/codeborne/selenide/commands/Commands.java
+++ b/src/main/java/com/codeborne/selenide/commands/Commands.java
@@ -8,10 +8,16 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static java.util.Arrays.copyOfRange;
+
 public class Commands {
+
+  private static final String CUSTOM_COMMAND = "customCommand";
+
   private static Commands collection;
 
   private final Map<String, Command> commands = new ConcurrentHashMap<>(128);
+  private final Map<String, Command> customCommands = new ConcurrentHashMap<>(128);
 
   public static synchronized Commands getInstance() {
     if (collection == null) {
@@ -23,6 +29,7 @@ public class Commands {
 
   public final synchronized void resetDefaults() {
     commands.clear();
+    customCommands.clear();
     addFindCommands();
     addClickCommands();
     addModifyCommands();
@@ -130,13 +137,21 @@ public class Commands {
     commands.put(method, command);
   }
 
+  public synchronized void addCustomCommand(String method, Command command) {
+    customCommands.put(method, command);
+  }
+
   @SuppressWarnings("unchecked")
-  public synchronized <T> T execute(Object proxy, WebElementSource webElementSource, String methodName, Object[] args) 
+  public synchronized <T> T execute(Object proxy, WebElementSource webElementSource, String methodName, Object[] args)
       throws IOException {
-    Command command = commands.get(methodName);
+
+    Command command = (CUSTOM_COMMAND.equals(methodName)) ? customCommands.get(args[0]) : commands.get(methodName);
     if (command == null) {
       throw new IllegalArgumentException("Unknown Selenide method: " + methodName);
     }
-    return (T) command.execute((SelenideElement) proxy, webElementSource, args);
+
+    Object[] argsToForward = (CUSTOM_COMMAND.equals(methodName)) ? copyOfRange(args, 1, args.length) : args;
+
+    return (T) command.execute((SelenideElement) proxy, webElementSource, argsToForward);
   }
 }

--- a/src/test/java/integration/customcommands/CustomCommandsTest.java
+++ b/src/test/java/integration/customcommands/CustomCommandsTest.java
@@ -1,12 +1,14 @@
 package integration.customcommands;
 
 import com.codeborne.selenide.commands.Commands;
+
 import integration.IntegrationTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Selenide.$;
 import static integration.customcommands.MyFramework.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -29,6 +31,19 @@ public class CustomCommandsTest extends IntegrationTest {
     
     assertEquals(4, tripleClickCounter.get());
     assertEquals(1, quadrupleClickCounter.get());
+  }
+
+  @Test
+  public void userCanAddAnyCustomCommandsToSelenideElement() {
+    Commands.getInstance().addCustomCommand("myCommand", (proxy, locator, args) -> {
+        ((Runnable) args[0]).run();
+        return proxy;
+      });
+
+    final boolean[] checkFlag = {false};
+    $("#valid-image").customCommand("myCommand", (Runnable) () -> checkFlag[0] = true);
+
+    assertTrue(checkFlag[0]);
   }
 
   @Before


### PR DESCRIPTION
customCommands support
=====================
Basically supporting chaining of custom commands mixed in within SelenideElement. Example:
```java
Commands.getInstance().addCustomCommand("myCommand", (proxy, locator, args) -> {
        Integer i = (Integer) args[0];
        // do whatever you want
        return proxy;
      });

$("#valid-image").customCommand("myCommand", 1).click();
```