### PR TITLE
log proxy details only if it's not null

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/WebDriverThreadLocalContainer.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebDriverThreadLocalContainer.java
@@ -130,7 +130,9 @@ public class WebDriverThreadLocalContainer implements WebDriverContainer {
     
     if (webdriver != null && !holdBrowserOpen) {
       log.info("Close webdriver: " + thread.getId() + " -> " + webdriver);
-      log.info("Close proxy server: " + thread.getId() + " -> " + proxy);
+      if (proxy != null) {
+        log.info("Close proxy server: " + thread.getId() + " -> " + proxy);
+      }
 
       long start = System.currentTimeMillis();
 


### PR DESCRIPTION
Small bug fix that checks if proxy is not null before logging details about it. It's related to issue #517 