### PR TITLE
Issue#528 - Wrong ElementNotFound exception message

### DIFF
--- a/src/main/java/com/codeborne/selenide/commands/SelectOptionByTextOrIndex.java
+++ b/src/main/java/com/codeborne/selenide/commands/SelectOptionByTextOrIndex.java
@@ -1,8 +1,11 @@
 package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.Command;
+import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.ex.ElementNotFound;
 import com.codeborne.selenide.impl.WebElementSource;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.support.ui.Select;
 
 public class SelectOptionByTextOrIndex implements Command<Void> {
@@ -20,13 +23,21 @@ public class SelectOptionByTextOrIndex implements Command<Void> {
 
   private void selectOptionsByTexts(Select select, String[] texts) {
     for (String text : texts) {
-      select.selectByVisibleText(text);
+      try {
+        select.selectByVisibleText(text);
+      } catch (NoSuchElementException e) {
+        throw new ElementNotFound(text, Condition.exist, e);
+      }
     }
   }
 
   private void selectOptionsByIndexes(Select select, int[] indexes) {
     for (Integer index : indexes) {
-      select.selectByIndex(index);
+      try {
+        select.selectByIndex(index);
+      } catch (NoSuchElementException e) {
+        throw new ElementNotFound(String.valueOf(index), Condition.exist, e);
+      }
     }
   }
 }

--- a/src/test/java/integration/SelectsTest.java
+++ b/src/test/java/integration/SelectsTest.java
@@ -5,17 +5,24 @@ import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.ElementNotFound;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.openqa.selenium.By;
 
 import static com.codeborne.selenide.Condition.*;
 import static com.codeborne.selenide.Selectors.byName;
 import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.$x;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class SelectsTest extends IntegrationTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
   @Before
   public void openTestPage() {
     openFile("page_with_selects_without_jquery.html");
@@ -63,9 +70,20 @@ public class SelectsTest extends IntegrationTest {
     assertThat(select.getSelectedText(), equalTo("@мыло.ру"));
   }
 
-  @Test(expected = ElementNotFound.class)
-  public void throwsElementNotFound() {
-    $(By.xpath("//select[@name='domain']")).selectOption("unexisting-option");
+  @Test()
+  public void throwsElementNotFoundWithOptionsText() {
+    thrown.expect(ElementNotFound.class);
+    thrown.expectMessage("Element not found {unexisting-option}\n"
+        + "Expected: exist");
+    $x("//select[@name='domain']").selectOption("unexisting-option");
+  }
+
+  @Test()
+  public void throwsElementNotFoundWithOptionsIndex() {
+    thrown.expect(ElementNotFound.class);
+    thrown.expectMessage("Element not found {999}\n"
+        + "Expected: exist");
+    $x("//select[@name='domain']").selectOption(999);
   }
 
   @Test


### PR DESCRIPTION
Show a corresponding option text or index in NotFoundException instead of a select locator in case when option doesn't exists in the select.