### PR TITLE
#529 Cannot find capabilities with browserName=ie when grid hub url specified

### DIFF
--- a/src/main/java/com/codeborne/selenide/WebDriverRunner.java
+++ b/src/main/java/com/codeborne/selenide/WebDriverRunner.java
@@ -14,6 +14,7 @@ public class WebDriverRunner {
 
   public static final String CHROME = "chrome";
   public static final String INTERNET_EXPLORER = "ie";
+  public static final String IE_FULL_NAME = "internet explorer";
   public static final String EDGE = "edge";
   public static final String FIREFOX = "firefox";
   /**
@@ -175,7 +176,8 @@ public class WebDriverRunner {
    * Is Selenide configured to use Internet Explorer browser
    */
   public static boolean isIE() {
-    return INTERNET_EXPLORER.equalsIgnoreCase(browser);
+    return INTERNET_EXPLORER.equalsIgnoreCase(browser) || IE_FULL_NAME
+        .equalsIgnoreCase(browser);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/webdriver/WebDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/WebDriverFactory.java
@@ -2,6 +2,7 @@ package com.codeborne.selenide.webdriver;
 
 import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.WebDriverProvider;
+import com.codeborne.selenide.WebDriverRunner;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.Proxy;
@@ -76,7 +77,7 @@ public class WebDriverFactory {
   protected WebDriver createRemoteDriver(String remote, String browser, Proxy proxy) {
     try {
       DesiredCapabilities capabilities = createCommonCapabilities(proxy);
-      capabilities.setBrowserName(browser);
+      capabilities.setBrowserName(isIE() ? WebDriverRunner.IE_FULL_NAME : browser);
       return new RemoteWebDriver(new URL(remote), capabilities);
     } catch (MalformedURLException e) {
       throw new IllegalArgumentException("Invalid 'remote' parameter: " + remote, e);

--- a/src/test/java/com/codeborne/selenide/webdriver/InternetExplorerNamesTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/InternetExplorerNamesTest.java
@@ -1,0 +1,22 @@
+package com.codeborne.selenide.webdriver;
+
+import com.codeborne.selenide.Configuration;
+import org.junit.Test;
+
+import static com.codeborne.selenide.WebDriverRunner.isIE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class InternetExplorerNamesTest {
+  @Test
+  public void internetExplorerShortNameTest() {
+    Configuration.browser = "ie";
+    assertThat(isIE(), is(true));
+  }
+
+  @Test
+  public void internetExplorerFullNameTest() {
+    Configuration.browser = "internet explorer";
+    assertThat(isIE(), is(true));
+  }
+}


### PR DESCRIPTION
- Set correct correct IE browser name in capabilities
- Add ability to set IE browser through "internet explorer" string

I reproduced issue and verified fix locally with IE 11 and selenium v.3.4.0