### PR TITLE
findAndAssertElementExists before performing scrollTo and getText

### DIFF
--- a/src/main/java/com/codeborne/selenide/commands/GetText.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetText.java
@@ -10,7 +10,7 @@ public class GetText implements Command<String> {
   
   @Override
   public String execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
-    WebElement element = locator.findAndAssertElementIsVisible();
+    WebElement element = locator.findAndAssertElementExists();
     return "select".equalsIgnoreCase(element.getTagName()) ? 
         getSelectedText.execute(proxy, locator, args) : 
         element.getText();

--- a/src/main/java/com/codeborne/selenide/commands/GetText.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetText.java
@@ -10,7 +10,7 @@ public class GetText implements Command<String> {
   
   @Override
   public String execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
-    WebElement element = locator.getWebElement();
+    WebElement element = locator.findAndAssertElementIsVisible();
     return "select".equalsIgnoreCase(element.getTagName()) ? 
         getSelectedText.execute(proxy, locator, args) : 
         element.getText();

--- a/src/main/java/com/codeborne/selenide/commands/ScrollTo.java
+++ b/src/main/java/com/codeborne/selenide/commands/ScrollTo.java
@@ -11,7 +11,7 @@ import static com.codeborne.selenide.Selenide.executeJavaScript;
 public class ScrollTo implements Command<WebElement> {
   @Override
   public WebElement execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
-    Point location = locator.getWebElement().getLocation();
+    Point location = locator.findAndAssertElementIsVisible().getLocation();
     executeJavaScript("window.scrollTo(" + location.getX() + ", " + location.getY() + ')');
     return proxy;
   }

--- a/src/main/java/com/codeborne/selenide/commands/ScrollTo.java
+++ b/src/main/java/com/codeborne/selenide/commands/ScrollTo.java
@@ -11,7 +11,7 @@ import static com.codeborne.selenide.Selenide.executeJavaScript;
 public class ScrollTo implements Command<WebElement> {
   @Override
   public WebElement execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
-    Point location = locator.findAndAssertElementIsVisible().getLocation();
+    Point location = locator.findAndAssertElementExists().getLocation();
     executeJavaScript("window.scrollTo(" + location.getX() + ", " + location.getY() + ')');
     return proxy;
   }

--- a/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
@@ -10,6 +10,7 @@ import org.openqa.selenium.WebElement;
 
 import java.util.List;
 
+import static com.codeborne.selenide.Condition.exist;
 import static com.codeborne.selenide.Condition.not;
 import static com.codeborne.selenide.Condition.visible;
 import static java.util.Collections.singletonList;
@@ -70,5 +71,9 @@ public abstract class WebElementSource {
 
   public WebElement findAndAssertElementIsVisible() {
     return checkCondition("be ", null, visible, false);
+  }
+
+  public WebElement findAndAssertElementExists() {
+    return checkCondition("be ", null, exist, false);
   }
 }


### PR DESCRIPTION
Have noticed that scrollTo and getText methods need to have a built-in wait before performing the action.
For example: 
`$(selenideElement).should(exist).scrollTo()` is necessary instead of just `$(selenideElement).scrollTo()`