### PR TITLE
Add TextsInAnyOrder #478 

### DIFF
--- a/src/main/java/com/codeborne/selenide/CollectionCondition.java
+++ b/src/main/java/com/codeborne/selenide/CollectionCondition.java
@@ -56,6 +56,24 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
   public static CollectionCondition texts(List<String> expectedTexts) {
     return new Texts(expectedTexts);
   }
+  
+  /**
+   * Checks that given collection has given texts in any order (each collection element CONTAINS corresponding text)
+   *
+   * <p>NB! Ignores multiple whitespaces between words</p>
+   */
+  public static CollectionCondition textsInAnyOrder(String... expectedTexts) {
+    return new TextsInAnyOrder(expectedTexts);
+  }
+  
+  /**
+   * Checks that given collection has given texts in any order (each collection element CONTAINS corresponding text)
+   *
+   * <p>NB! Ignores multiple whitespaces between words</p>
+   */
+  public static CollectionCondition textsInAnyOrder(List<String> expectedTexts) {
+    return new TextsInAnyOrder(expectedTexts);
+  }
 
   /**
    * Checks that given collection has given texts (each collection element EQUALS TO corresponding text)

--- a/src/main/java/com/codeborne/selenide/collections/TextsInAnyOrder.java
+++ b/src/main/java/com/codeborne/selenide/collections/TextsInAnyOrder.java
@@ -23,13 +23,13 @@ public class TextsInAnyOrder extends ExactTexts {
     for (int i = 0; i < expectedTexts.size(); i++) {
       String expectedText = expectedTexts.get(i);
       boolean bFound = false;
-      for(WebElement element: elements) {
-    	  if (Html.text.contains(element.getText(), expectedText)) {
-    		  bFound = true;
-    	  }
+      for (WebElement element: elements) {
+        if (Html.text.contains(element.getText(), expectedText)) {
+          bFound = true;
+        }
       }
-      if(bFound == false) {
-    	  return false;
+      if (bFound == false) {
+        return false;
       }
     }
     return true;

--- a/src/main/java/com/codeborne/selenide/collections/TextsInAnyOrder.java
+++ b/src/main/java/com/codeborne/selenide/collections/TextsInAnyOrder.java
@@ -1,0 +1,42 @@
+package com.codeborne.selenide.collections;
+
+import com.codeborne.selenide.impl.Html;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+public class TextsInAnyOrder extends ExactTexts {
+  public TextsInAnyOrder(String... expectedTexts) {
+    super(expectedTexts);
+  }
+
+  public TextsInAnyOrder(List<String> expectedTexts) {
+    super(expectedTexts);
+  }
+
+  @Override
+  public boolean apply(List<WebElement> elements) {
+    if (elements.size() != expectedTexts.size()) {
+      return false;
+    }
+
+    for (int i = 0; i < expectedTexts.size(); i++) {
+      String expectedText = expectedTexts.get(i);
+      boolean bFound = false;
+      for(WebElement element: elements) {
+    	  if (Html.text.contains(element.getText(), expectedText)) {
+    		  bFound = true;
+    	  }
+      }
+      if(bFound == false) {
+    	  return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "TextsInAnyOrder " + expectedTexts;
+  }
+}

--- a/src/test/java/com/codeborne/selenide/collections/TextsInAnyOrderTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/TextsInAnyOrderTest.java
@@ -1,0 +1,61 @@
+package com.codeborne.selenide.collections;
+
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TextsInAnyOrderTest {
+
+  @Test
+  public void testApplyWithSameOrder() {
+    TextsInAnyOrder texts = new TextsInAnyOrder(asList("One", "Two", "Three"));
+    testApplyMethod(true, texts);
+  }
+  
+  @Test
+  public void testApplyWithDifferentOrder() {
+    TextsInAnyOrder texts = new TextsInAnyOrder(asList("Two", "One", "Three"));
+    testApplyMethod(true, texts);
+  }
+  
+  @Test
+  public void testApplyWithWrongListSize() {
+    TextsInAnyOrder texts = new TextsInAnyOrder(asList("Two", "One"));
+    testApplyMethod(false, texts);
+  }
+  
+   @Test
+  public void testApplyWithBiggerSize() {
+    TextsInAnyOrder texts = new TextsInAnyOrder(asList("Two", "One", "four", "three"));
+    testApplyMethod(false, texts);
+  }
+
+
+
+  private void testApplyMethod(boolean shouldMatch, TextsInAnyOrder texts) {
+   WebElement mockElement1 = mock(WebElement.class);
+    WebElement mockElement2 = mock(WebElement.class);
+    WebElement mockElement3 = mock(WebElement.class);
+
+    when(mockElement1.getText()).thenReturn("One");
+    when(mockElement2.getText()).thenReturn("Two");
+    when(mockElement3.getText()).thenReturn("Three");
+    assertEquals(shouldMatch, texts.apply(asList(mockElement1, mockElement2, mockElement3)));
+  
+	  
+  }
+  
+  @Test
+  public void testToString() {
+    assertEquals("TextsInAnyOrder [One, Two]", new TextsInAnyOrder(asList("One", "Two")).toString());
+  }
+
+}

--- a/src/test/java/com/codeborne/selenide/collections/TextsInAnyOrderTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/TextsInAnyOrderTest.java
@@ -4,11 +4,7 @@ import org.junit.Test;
 import org.openqa.selenium.WebElement;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -32,7 +28,7 @@ public class TextsInAnyOrderTest {
     testApplyMethod(false, texts);
   }
   
-   @Test
+  @Test
   public void testApplyWithBiggerSize() {
     TextsInAnyOrder texts = new TextsInAnyOrder(asList("Two", "One", "four", "three"));
     testApplyMethod(false, texts);
@@ -41,7 +37,7 @@ public class TextsInAnyOrderTest {
 
 
   private void testApplyMethod(boolean shouldMatch, TextsInAnyOrder texts) {
-   WebElement mockElement1 = mock(WebElement.class);
+    WebElement mockElement1 = mock(WebElement.class);
     WebElement mockElement2 = mock(WebElement.class);
     WebElement mockElement3 = mock(WebElement.class);
 
@@ -49,8 +45,6 @@ public class TextsInAnyOrderTest {
     when(mockElement2.getText()).thenReturn("Two");
     when(mockElement3.getText()).thenReturn("Three");
     assertEquals(shouldMatch, texts.apply(asList(mockElement1, mockElement2, mockElement3)));
-  
-	  
   }
   
   @Test


### PR DESCRIPTION
#478 
TextsInAnyOrder compares two lists ignoring order.

Currently, I used assertThat().contains(...) for this.
```
assertThat(projectSettingPage.productsInUse.texts()).contains("Push", "Image", "Email");
```

Using texts() failed.
```
projectSettingPage.productsInUse.shouldBe(texts("Push", "Image", "Email"));
=> TextsMismatch 
Actual: [Image, Push, Email]
Expected: [Push, Image, Email]
```

Now, I can simply compare two lists ignoring order.
```
projectSettingPage.productsInUse.shouldBe(textsInAnyOrder("Push", "Image", "Email"));
=> Pass
```
