### PR TITLE
Added method promt() for promt js alerts with input field

### DIFF
--- a/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/src/main/java/com/codeborne/selenide/Selenide.java
@@ -529,6 +529,45 @@ public class Selenide {
     return null;
   }
 
+  /**
+   * Accept (Click "Yes" or "Ok") in the confirmation dialog (javascript 'promt').
+   * @return actual dialog text
+   */
+  public static String promt() {
+    return promt(null, null);
+  }
+
+  /**
+   * Accept (Click "Yes" or "Ok") in the confirmation dialog (javascript 'promt').
+   * @param inputText if not null, sets value in promt dialog input
+   * @return actual dialog text
+   */
+  public static String promt(String inputText) {
+    return promt(null, inputText);
+  }
+
+  /**
+   * Accept (Click "Yes" or "Ok") in the confirmation dialog (javascript 'promt').
+   * Method does nothing in case of HtmlUnit browser (since HtmlUnit does not support alerts).
+   *
+   * @param expectedDialogText if not null, check that confirmation dialog displays this message (case-sensitive)
+   * @param inputText if not null, sets value in promt dialog input
+   * @throws DialogTextMismatch if confirmation message differs from expected message
+   * @return actual dialog text
+   */
+  public static String promt(String expectedDialogText, String inputText) {
+    if (!doDismissModalDialogs()) {
+      Alert alert = switchTo().alert();
+      String actualDialogText = alert.getText();
+      if (inputText != null)
+        alert.sendKeys(inputText);
+      alert.accept();
+      checkDialogText(expectedDialogText, actualDialogText);
+      return actualDialogText;
+    }
+    return null;
+  }
+
 
   /**
    * Dismiss (click "No" or "Cancel") in the confirmation dialog (javascript 'alert' or 'confirm').

--- a/src/test/java/integration/AlertTest.java
+++ b/src/test/java/integration/AlertTest.java
@@ -9,9 +9,7 @@ import org.openqa.selenium.By;
 import static com.codeborne.selenide.Condition.empty;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Selectors.byValue;
-import static com.codeborne.selenide.Selenide.$;
-import static com.codeborne.selenide.Selenide.close;
-import static com.codeborne.selenide.Selenide.confirm;
+import static com.codeborne.selenide.Selenide.*;
 import static com.codeborne.selenide.WebDriverRunner.supportsModalDialogs;
 import static org.junit.Assert.fail;
 
@@ -27,6 +25,14 @@ public class AlertTest extends IntegrationTest {
     $(byValue("Alert button")).click();
     confirm("Are you sure, Greg?");
     $("#message").shouldHave(text("Hello, Greg!"));
+    $("#container").shouldBe(empty);
+  }
+
+  @Test
+  public void canSubmitPromtDialog() {
+    $(byValue("Promt button")).click();
+    promt("Please input your username", "Aegon Targaryen");
+    $("#message").shouldHave(text("Hello, Aegon Targaryen!"));
     $("#container").shouldBe(empty);
   }
 

--- a/src/test/resources/page_with_alerts.html
+++ b/src/test/resources/page_with_alerts.html
@@ -16,6 +16,12 @@
         document.getElementById('container').innerHTML = '';
       }
 
+      function runPromt() {
+        var username = prompt("Please input your username");
+        document.getElementById('message').innerHTML = 'Hello, ' + username + '!';
+        document.getElementById('container').innerHTML = '';
+      }
+
       function triggerConfirm() {
         setTimeout(runConfirm, 1000);
         return false;
@@ -46,6 +52,7 @@
             <input id="username" name="username"/>
           </label> <br/>
           <input type="button" onclick="return runAlert();" value="Alert button"><br/><br/>
+          <input type="button" onclick="return runPromt();" value="Promt button"><br/><br/>
           <a href="page_with_jquery.html" onclick="return runConfirm();">Confirm button</a><br/><br/>
 
           <input type="button" onclick="return triggerAlert();" value="Slow alert"><br/><br/>


### PR DESCRIPTION
In some project I'm faced new alert() dialog - promt(). It created alert with input field ([Screenshot](http://take.ms/ja6o2)).
Js code example:
`var username = prompt("Please input your username");`

So I added new Selenide method promt(), that inputs some text in such alert.
```
public static String promt(String expectedDialogText, String inputText) {
    if (!doDismissModalDialogs()) {
      Alert alert = switchTo().alert();
      String actualDialogText = alert.getText();
      if (inputText != null)
        alert.sendKeys(inputText);
      alert.accept();
      checkDialogText(expectedDialogText, actualDialogText);
      return actualDialogText;
    }
    return null;
  }
```
Also I added tests in AlertTest, and modified html page for tests.