### PR TITLE
Make travis-ci build fail logs more friendly

### DIFF
--- a/.upload_reports.sh
+++ b/.upload_reports.sh
@@ -9,12 +9,19 @@ if [ -z "$HERE" ] ; then
 fi
 
 ARTIFACTS_DIR="${HERE}/build/reports/"
-ARTIFACTS_FILE=${TRAVIS_JOB_NUMBER}_log.tar.gz
+ARTIFACTS_FILE=${TRAVIS_BUILD_NUMBER}_tests_report.tar.gz
+FAILURE_MESSAGE="\nBUILD FAILED. PLEASE READ CHECKSTYLE AND TEST RESULT REPORTS ON THE LINK ABOVE OR IN A LOG ABOVE\n"
+SUCCESS_MESSAGE="\nYOU CAN FIND TEST RESULTS REPORTS ON THE LINK ABOVE\n"
 
-ls $ARTIFACTS_DIR
 echo "COMPRESSING build artifacts."
-cd $ARTIFACTS_DIR
-tar -zcvf $ARTIFACTS_FILE *
-# upload to http://transfer.sh
-echo "Uploading to transfer.sh"
-curl --upload-file $ARTIFACTS_FILE http://transfer.sh
+cd ${ARTIFACTS_DIR}
+tar -zcf ${ARTIFACTS_FILE} *
+
+echo "Uploading build artifacts"
+curl --upload-file ${ARTIFACTS_FILE} https://transfer.sh/
+if [ $TRAVIS_TEST_RESULT -eq 0 ];
+then
+	echo -e ${SUCCESS_MESSAGE}
+else
+	echo -e ${FAILURE_MESSAGE}
+fi

--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,10 @@ task checkstyleHtmlTest {
   }
 }
 
+[checkstyleMain, checkstyleTest].each { task ->
+    task.logging.setLevel(LogLevel.LIFECYCLE)
+}
+
 checkstyleMain.finalizedBy checkstyleHtmlMain
 checkstyleTest.finalizedBy checkstyleHtmlTest
 

--- a/src/test/java/integration/SelenideMethodsTest.java
+++ b/src/test/java/integration/SelenideMethodsTest.java
@@ -305,7 +305,7 @@ public class SelenideMethodsTest extends IntegrationTest {
 
   @Test
   public void userCanFollowLinks() {
-    $(By.linkText("Want to see ajax in action?")).followLink();
+    $(By.linkText("Want to see ajax in action?")).scrollTo().followLink();
     assertTrue("Actual URL is: " + url(), url().contains("long_ajax_request.html"));
   }
 


### PR DESCRIPTION
- get rid of printing Checkstyle XSLT on checkstyle fail
- fix uploading /build/reports/ to https://transfer.sh/
- add message describes where you can find build artifacts