### PR TITLE
Fix checkstyle suppressions on Windows

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -5,23 +5,23 @@
         "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 
 <suppressions>
-    <suppress checks="JavadocMethod" files=".*\/impl\/.*.java"/>
-    <suppress checks="JavadocMethod" files=".*\/commands\/.*.java"/>
-    <suppress checks="JavadocMethod" files=".*\/ex\/.*.java"/>
-    <suppress checks="JavadocMethod" files=".*\/logevents\/.*.java"/>
-    <suppress checks="JavadocMethod" files=".*\/junit\/.*.java"/>
-    <suppress checks="JavadocMethod" files=".*\/testng\/.*.java"/>
-    <suppress checks="JavadocMethod" files=".*\/collections\/.*.java"/>
-    <suppress checks="JavadocMethod" files=".*\/conditions\/.*.java"/>
-    <suppress checks="JavadocMethod" files=".*\/webdriver\/.*.java"/>
-    <suppress checks="JavadocMethod" files=".*\/Command.java"/>
-    <suppress checks="JavadocMethod" files=".*\/ElementsContainer.java"/>
-    <suppress checks="JavadocMethod" files=".*\/Selectors.java"/>
-    <suppress checks="JavadocMethod" files=".*\/Screenshots.java"/>
-    <suppress checks="JavadocMethod" files=".*\/Selectors.java"/>
-    <suppress checks="JavadocMethod" files=".*\/Condition.java"/>
-    <suppress checks="JavadocMethod" files=".*\/ElementsCollection.java"/>
-    <suppress checks="JavadocMethod" files=".*\/CollectionCondition.java"/>
-    <suppress checks="JavadocMethod" files="src/test/java/.*"/>
-    <suppress checks="ClassFanOutComplexity" files=".*\/Commands.java"/>
+    <suppress checks="JavadocMethod" files=".*[/\\]impl[/\\].*.java"/>
+    <suppress checks="JavadocMethod" files=".*[/\\]commands[/\\].*.java"/>
+    <suppress checks="JavadocMethod" files=".*[/\\]ex[/\\].*.java"/>
+    <suppress checks="JavadocMethod" files=".*[/\\]logevents[/\\].*.java"/>
+    <suppress checks="JavadocMethod" files=".*[/\\]junit[/\\].*.java"/>
+    <suppress checks="JavadocMethod" files=".*[/\\]testng[/\\].*.java"/>
+    <suppress checks="JavadocMethod" files=".*[/\\]collections[/\\].*.java"/>
+    <suppress checks="JavadocMethod" files=".*[/\\]conditions[/\\].*.java"/>
+    <suppress checks="JavadocMethod" files=".*[/\\]webdriver[/\\].*.java"/>
+    <suppress checks="JavadocMethod" files=".*[/\\]Command.java"/>
+    <suppress checks="JavadocMethod" files=".*[/\\]ElementsContainer.java"/>
+    <suppress checks="JavadocMethod" files=".*[/\\]Selectors.java"/>
+    <suppress checks="JavadocMethod" files=".*[/\\]Screenshots.java"/>
+    <suppress checks="JavadocMethod" files=".*[/\\]Selectors.java"/>
+    <suppress checks="JavadocMethod" files=".*[/\\]Condition.java"/>
+    <suppress checks="JavadocMethod" files=".*[/\\]ElementsCollection.java"/>
+    <suppress checks="JavadocMethod" files=".*[/\\]CollectionCondition.java"/>
+    <suppress checks="JavadocMethod" files="src[/\\]test[/\\]java[/\\].*"/>
+    <suppress checks="ClassFanOutComplexity" files=".*[/\\]Commands.java"/>
 </suppressions>


### PR DESCRIPTION
On windows` ./gradle check` doesn't work correctly, we always get errors "Missing a Javadoc comment" 
It confuses people.