### PR TITLE
Update the project to selenium 3.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ configurations {
 dependencies {
   compile group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '1.7.2'
   compile('org.apache.httpcomponents:httpcore:4.4.6')
-  compile('org.seleniumhq.selenium:selenium-java:3.5.3') {
+  compile('org.seleniumhq.selenium:selenium-java:3.6.0') {
     exclude group: 'org.seleniumhq.selenium', module: 'selenium-android-driver'
     exclude group: 'org.seleniumhq.selenium', module: 'selenium-iphone-driver'
     exclude group: 'org.seleniumhq.selenium', module: 'selenium-safari-driver'
@@ -60,7 +60,7 @@ dependencies {
   compile 'com.google.guava:guava:21.0'
   runtime 'commons-codec:commons-codec:1.10'
   provided group: 'org.seleniumhq.selenium', name: 'htmlunit-driver', version: '2.27', transitive: false
-  provided group: 'net.sourceforge.htmlunit', name: 'htmlunit', version: '2.27', transitive: false
+  provided group: 'net.sourceforge.htmlunit', name: 'htmlunit', version: '2.27'
   testRuntime group: 'net.sourceforge.htmlunit', name: 'htmlunit', version: '2.27', transitive: false
   compile('net.lightbody.bmp:browsermob-core:2.1.5')
   testRuntime group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25', transitive: false
@@ -68,7 +68,7 @@ dependencies {
   provided 'junit:junit:4.12'
   provided 'org.testng:testng:6.9.10'
   
-  testCompile group: 'org.seleniumhq.selenium', name: 'selenium-server', version: '3.5.3', transitive: false
+  testCompile group: 'org.seleniumhq.selenium', name: 'selenium-server', version: '3.6.0', transitive: false
   testCompile 'org.mockito:mockito-core:2.8.9'
   testCompile 'org.seleniumhq.selenium:jetty-repacked:9.4.5.v20170502'
   testCompile 'org.eclipse.jetty:jetty-server:9.4.5.v20170502'

--- a/src/main/java/com/codeborne/selenide/Configuration.java
+++ b/src/main/java/com/codeborne/selenide/Configuration.java
@@ -358,5 +358,11 @@ public class Configuration {
    */
   public static boolean driverManagerEnabled = Boolean.parseBoolean(System.getProperty("selenide.driverManagerEnabled", "true"));
 
-
+  /**
+   * Enables the ability to run the browser in headless mode.
+   * Works only for Chrome(59+) and Firefox(56+).
+   *
+   * Default: false
+   */
+  public static boolean headless = Boolean.parseBoolean(System.getProperty("selenide.headless", "false"));
 }

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -15,7 +15,7 @@ import java.io.FileNotFoundException;
  */
 public interface SelenideElement extends WebElement, FindsByLinkText, FindsById, FindsByName,
     FindsByTagName, FindsByClassName, FindsByCssSelector,
-    FindsByXPath, WrapsDriver, WrapsElement, Locatable {
+    FindsByXPath, WrapsDriver, WrapsElement, org.openqa.selenium.interactions.internal.Locatable {
 
   /**
    * <p>

--- a/src/main/java/com/codeborne/selenide/impl/WebDriverThreadLocalContainer.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebDriverThreadLocalContainer.java
@@ -4,7 +4,6 @@ import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.proxy.SelenideProxyServer;
 import com.codeborne.selenide.webdriver.WebDriverFactory;
 import org.openqa.selenium.*;
-import org.openqa.selenium.internal.Killable;
 import org.openqa.selenium.remote.UnreachableBrowserException;
 import org.openqa.selenium.support.events.EventFiringWebDriver;
 import org.openqa.selenium.support.events.WebDriverEventListener;
@@ -23,7 +22,6 @@ import static com.codeborne.selenide.Configuration.*;
 import static com.codeborne.selenide.impl.Describe.describe;
 import static java.lang.Thread.currentThread;
 import static java.util.logging.Level.FINE;
-import static java.util.logging.Level.SEVERE;
 
 public class WebDriverThreadLocalContainer implements WebDriverContainer {
   private static final Logger log = Logger.getLogger(WebDriverThreadLocalContainer.class.getName());
@@ -127,7 +125,7 @@ public class WebDriverThreadLocalContainer implements WebDriverContainer {
     ALL_WEB_DRIVERS_THREADS.remove(thread);
     WebDriver webdriver = THREAD_WEB_DRIVER.remove(thread.getId());
     SelenideProxyServer proxy = THREAD_PROXY_SERVER.remove(thread.getId());
-    
+
     if (webdriver != null && !holdBrowserOpen) {
       log.info("Close webdriver: " + thread.getId() + " -> " + webdriver);
       if (proxy != null) {
@@ -185,23 +183,10 @@ public class WebDriverThreadLocalContainer implements WebDriverContainer {
       catch (WebDriverException cannotCloseBrowser) {
         log.severe("Cannot close browser normally: " + Cleanup.of.webdriverExceptionMessage(cannotCloseBrowser));
       }
-      finally {
-        killBrowser(webdriver);
-      }
-      
+
       if (proxy != null) {
         log.info("Trying to shutdown " + proxy + " ...");
         proxy.shutdown();
-      }
-    }
-
-    protected void killBrowser(WebDriver webdriver) {
-      if (webdriver instanceof Killable) {
-        try {
-          ((Killable) webdriver).kill();
-        } catch (Exception e) {
-          log.log(SEVERE, "Failed to kill browser " + webdriver + ':', e);
-        }
       }
     }
   }
@@ -231,7 +216,7 @@ public class WebDriverThreadLocalContainer implements WebDriverContainer {
 
   protected WebDriver createDriver() {
     Proxy userProvidedProxy = proxy;
-    
+
     if (Configuration.fileDownload == PROXY) {
       SelenideProxyServer selenideProxyServer = new SelenideProxyServer(proxy);
       selenideProxyServer.start();
@@ -242,7 +227,7 @@ public class WebDriverThreadLocalContainer implements WebDriverContainer {
     WebDriver webdriver = factory.createWebDriver(userProvidedProxy);
 
     log.info("Create webdriver in current thread " + currentThread().getId() + ": " +
-        describe(webdriver) + " -> " + webdriver);
+            describe(webdriver) + " -> " + webdriver);
 
     return markForAutoClose(addListeners(webdriver));
   }

--- a/src/main/java/com/codeborne/selenide/webdriver/AbstractDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/AbstractDriverFactory.java
@@ -1,22 +1,19 @@
 package com.codeborne.selenide.webdriver;
 
-import static com.codeborne.selenide.Configuration.browserVersion;
-import static com.codeborne.selenide.Configuration.pageLoadStrategy;
-import static com.codeborne.selenide.WebDriverRunner.isPhantomjs;
-import static org.openqa.selenium.remote.CapabilityType.ACCEPT_SSL_CERTS;
-import static org.openqa.selenium.remote.CapabilityType.PROXY;
-import static org.openqa.selenium.remote.CapabilityType.SUPPORTS_ALERTS;
-import static org.openqa.selenium.remote.CapabilityType.TAKES_SCREENSHOT;
-
 import com.codeborne.selenide.WebDriverProvider;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.util.logging.Logger;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.logging.Logger;
+
+import static com.codeborne.selenide.Configuration.browserVersion;
+import static com.codeborne.selenide.Configuration.pageLoadStrategy;
+import static com.codeborne.selenide.WebDriverRunner.isPhantomjs;
+import static org.openqa.selenium.remote.CapabilityType.*;
 
 abstract class AbstractDriverFactory {
 
@@ -31,7 +28,6 @@ abstract class AbstractDriverFactory {
       DesiredCapabilities capabilities = createCommonCapabilities(proxy);
       capabilities.setJavascriptEnabled(true);
       capabilities.setCapability(TAKES_SCREENSHOT, true);
-      capabilities.setCapability(ACCEPT_SSL_CERTS, true);
       capabilities.setCapability(SUPPORTS_ALERTS, true);
       if (isPhantomjs()) {
         capabilities.setCapability("phantomjs.cli.args", // PhantomJSDriverService.PHANTOMJS_CLI_ARGS == "phantomjs.cli.args"
@@ -66,14 +62,15 @@ abstract class AbstractDriverFactory {
     if (browserVersion != null && !browserVersion.isEmpty()) {
       browserCapabilities.setVersion(browserVersion);
     }
-    browserCapabilities.setCapability(CapabilityType.PAGE_LOAD_STRATEGY, pageLoadStrategy);
-    browserCapabilities.setCapability("acceptSslCerts", true);
+    browserCapabilities.setCapability(PAGE_LOAD_STRATEGY, pageLoadStrategy);
+    browserCapabilities.setCapability(ACCEPT_SSL_CERTS, true);
 
-    browserCapabilities = transferCapabilitiesFromSystemProperties(browserCapabilities, "capabilities.");
+    transferCapabilitiesFromSystemProperties(browserCapabilities);
     return browserCapabilities;
   }
 
-  private DesiredCapabilities transferCapabilitiesFromSystemProperties(DesiredCapabilities currentBrowserCapabilities, String prefix) {
+  private void transferCapabilitiesFromSystemProperties(DesiredCapabilities currentBrowserCapabilities) {
+    String prefix = "capabilities.";
     for (String key : System.getProperties().stringPropertyNames()) {
       if (key.startsWith(prefix)) {
         String capability = key.substring(prefix.length());
@@ -88,6 +85,5 @@ abstract class AbstractDriverFactory {
         }
       }
     }
-    return currentBrowserCapabilities;
   }
 }

--- a/src/main/java/com/codeborne/selenide/webdriver/EdgeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/EdgeDriverFactory.java
@@ -3,7 +3,8 @@ package com.codeborne.selenide.webdriver;
 import com.codeborne.selenide.WebDriverRunner;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.ie.InternetExplorerDriver;
+import org.openqa.selenium.edge.EdgeDriver;
+import org.openqa.selenium.edge.EdgeOptions;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 class EdgeDriverFactory extends AbstractDriverFactory {
@@ -20,6 +21,8 @@ class EdgeDriverFactory extends AbstractDriverFactory {
 
   private WebDriver createInternetExplorerDriver(final Proxy proxy) {
     DesiredCapabilities capabilities = createCommonCapabilities(proxy);
-    return new InternetExplorerDriver(capabilities);
+    EdgeOptions options = new EdgeOptions();
+    options.merge(capabilities);
+    return new EdgeDriver(options);
   }
 }

--- a/src/main/java/com/codeborne/selenide/webdriver/EdgeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/EdgeDriverFactory.java
@@ -11,7 +11,7 @@ class EdgeDriverFactory extends AbstractDriverFactory {
 
   @Override
   WebDriver create(final Proxy proxy) {
-    return createInternetExplorerDriver(proxy);
+    return createEdgeDriver(proxy);
   }
 
   @Override
@@ -19,7 +19,7 @@ class EdgeDriverFactory extends AbstractDriverFactory {
     return WebDriverRunner.isEdge();
   }
 
-  private WebDriver createInternetExplorerDriver(final Proxy proxy) {
+  private WebDriver createEdgeDriver(final Proxy proxy) {
     DesiredCapabilities capabilities = createCommonCapabilities(proxy);
     EdgeOptions options = new EdgeOptions();
     options.merge(capabilities);

--- a/src/main/java/com/codeborne/selenide/webdriver/InternetExplorerDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/InternetExplorerDriverFactory.java
@@ -4,6 +4,7 @@ import com.codeborne.selenide.WebDriverRunner;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.ie.InternetExplorerDriver;
+import org.openqa.selenium.ie.InternetExplorerOptions;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 class InternetExplorerDriverFactory extends AbstractDriverFactory {
@@ -20,6 +21,7 @@ class InternetExplorerDriverFactory extends AbstractDriverFactory {
 
   private WebDriver createInternetExplorerDriver(final Proxy proxy) {
     DesiredCapabilities capabilities = createCommonCapabilities(proxy);
-    return new InternetExplorerDriver(capabilities);
+    InternetExplorerOptions options = new InternetExplorerOptions(capabilities);
+    return new InternetExplorerDriver(options);
   }
 }

--- a/src/main/java/com/codeborne/selenide/webdriver/MarionetteDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/MarionetteDriverFactory.java
@@ -4,7 +4,7 @@ import com.codeborne.selenide.WebDriverRunner;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.firefox.FirefoxOptions;
 
 class MarionetteDriverFactory extends FirefoxDriverFactory {
 
@@ -19,8 +19,8 @@ class MarionetteDriverFactory extends FirefoxDriverFactory {
   }
 
   private WebDriver createMarionetteDriver(final Proxy proxy) {
-    DesiredCapabilities capabilities = createFirefoxCapabilities(proxy);
-    capabilities.setCapability("marionette", true);
-    return new FirefoxDriver(capabilities);
+    FirefoxOptions firefoxOptions = createFirefoxOptions(proxy);
+    firefoxOptions.setCapability("marionette", true);
+    return new FirefoxDriver(firefoxOptions);
   }
 }

--- a/src/test/java/com/codeborne/selenide/webdriver/FirefoxDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/FirefoxDriverFactoryTest.java
@@ -1,18 +1,20 @@
 package com.codeborne.selenide.webdriver;
 
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
-
 import com.codeborne.selenide.Configuration;
-import java.io.IOException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.Proxy;
-import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxProfile;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class FirefoxDriverFactoryTest {
 
@@ -54,8 +56,7 @@ public class FirefoxDriverFactoryTest {
   @Test
   public void transferIntegerFirefoxProfilePreferencesFromSystemPropsToDriver() {
     System.setProperty("firefoxprofile.some.cap", "25");
-    FirefoxProfile profile = (FirefoxProfile) driverFactory.createFirefoxCapabilities(proxy).getCapability(
-        FirefoxDriver.PROFILE);
+    FirefoxProfile profile = driverFactory.createFirefoxOptions(proxy).getProfile();
     assertThat(profile.getIntegerPreference("some.cap", 0), is(25));
 
   }
@@ -63,22 +64,24 @@ public class FirefoxDriverFactoryTest {
   @Test
   public void transferBooleanFirefoxProfilePreferencesFromSystemPropsToDriver() {
     System.setProperty("firefoxprofile.some.cap", "false");
-    FirefoxProfile profile = (FirefoxProfile) driverFactory.createFirefoxCapabilities(proxy).getCapability(FirefoxDriver.PROFILE);
+    FirefoxProfile profile = driverFactory.createFirefoxOptions(proxy).getProfile();
     assertThat(profile.getBooleanPreference("some.cap", true), is(false));
   }
 
   @Test
   public void transferStringFirefoxProfilePreferencesFromSystemPropsToDriver() {
     System.setProperty("firefoxprofile.some.cap", "abdd");
-    FirefoxProfile profile = (FirefoxProfile) driverFactory.createFirefoxCapabilities(proxy).getCapability(FirefoxDriver.PROFILE);
+    FirefoxProfile profile = driverFactory.createFirefoxOptions(proxy).getProfile();
     assertThat(profile.getStringPreference("some.cap", "sjlj"), is("abdd"));
   }
 
   @Test
   public void transferChromeOptionArgumentsFromSystemPropsToDriver() throws IOException {
     System.setProperty("chromeoptions.args", "abdd,--abcd,xcvcd=123");
-    String arrayOfArguments = new ChromeDriverFactory().createChromeOptions().toJson()
-        .getAsJsonObject().getAsJsonArray("args").toString();
+    String chromeOptions = new ChromeDriverFactory().createChromeOptions(proxy).toString();
+    Matcher matcher = Pattern.compile("args=\\[(.*)\\],").matcher(chromeOptions);
+    matcher.find();
+    String arrayOfArguments = matcher.group(1);
 
     assertThat(arrayOfArguments, containsString("abdd"));
     assertThat(arrayOfArguments, containsString("--abcd"));

--- a/src/test/java/integration/FirefoxWithProfileTest.java
+++ b/src/test/java/integration/FirefoxWithProfileTest.java
@@ -4,6 +4,7 @@ import com.codeborne.selenide.WebDriverRunner;
 import org.junit.Test;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
 
 import java.io.File;
@@ -17,7 +18,7 @@ public class FirefoxWithProfileTest extends IntegrationTest {
     assumeTrue(WebDriverRunner.isFirefox());
 
     FirefoxProfile profile = createFirefoxProfileWithExtensions();
-    WebDriver driver = new FirefoxDriver(profile);
+    WebDriver driver = new FirefoxDriver(new FirefoxOptions().setProfile(profile));
     driver.manage().window().maximize();
     try {
       WebDriverRunner.setWebDriver(driver);
@@ -37,7 +38,6 @@ public class FirefoxWithProfileTest extends IntegrationTest {
     profile.addExtension(new File(currentThread().getContextClassLoader().getResource("firepath-0.9.7-fx.xpi").getPath()));
     profile.setPreference("extensions.firebug.showFirstRunPage", false);
     profile.setPreference("extensions.firebug.allPagesActivation", "on");
-    profile.setEnableNativeEvents(true);
     profile.setPreference("intl.accept_languages", "no,en-us,en");
     profile.setPreference("extensions.firebug.console.enableSites", "true");
     return profile;

--- a/src/test/java/integration/ScreenshotTest.java
+++ b/src/test/java/integration/ScreenshotTest.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.WebDriverRunner.getWebDriver;
 import static com.codeborne.selenide.WebDriverRunner.isHtmlUnit;
+import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.*;
@@ -36,13 +37,13 @@ public class ScreenshotTest extends IntegrationTest {
     SelenideElement element = $("#small_div");
     File screenshot = element.screenshot();
     String info = "(Screenshot of element: " + screenshot.getAbsolutePath() + ") ";
+    String screenshotPath = IS_OS_WINDOWS ? Configuration.reportsFolder.replace("/", "\\") : Configuration.reportsFolder;
 
     BufferedImage img = ImageIO.read(screenshot);
     assertEquals("Screenshot doesn't fit width " + info, img.getWidth(), element.getSize().getWidth());
     assertEquals("Screenshot doesn't fit height " + info, img.getHeight(), element.getSize().getHeight());
-    assertTrue("Screenshot file should be located in " + Configuration.reportsFolder +
-            ", but was: " + screenshot.getPath(),
-        screenshot.getPath().startsWith(Configuration.reportsFolder));
+    assertTrue("Screenshot file should be located in " + screenshotPath + ", but was: " +
+            screenshot.getPath(), screenshot.getPath().startsWith(screenshotPath));
   }
 
   @Test


### PR DESCRIPTION
## Proposed changes
1. Updated project to use selenium 3.6.0. In this version the htmlunit dependency was removed from selenium-java. I removed the transitive property from htmlunit in order for the project to compile(I'm really not sure if this is the right way to do it, as I haven't worked with gradle before).
2. Since version 3.6.0 the WebDriver constructor that accepts Capabilities object is deprecated and will be removed in the future. The recommended way of creating the webdriver is using browser specific options(e.g. FirefoxOptions, ChromeOptions etc.). I replaced the Capabilities with browser specific option classes where possible.
4. Replaced the deprecated Locatable interface with recommended org.openqa.selenium.interactions.internal.Locatable
5. Fixed EdgeDriverFactory. For some reason it was creating a InternetExplorerDriver instead of EdgeDriver.
6. Removed killBrowser() from WebDriverThreadLocalContainer. The Killable interface is removed from selenium 3.6. Not really sure what this method did before, as the Killable interface wasn't implemented by any class.
7.  Since version 3.6 there is a possibility to start chrome and firefox in a headless mode using browser options(which makes htmlunit kinda obsolete). I added headless property to Configuration class to be able to use that in selenide.
8. Fixed some tests accordingly with he new changes.

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [-] I have added tests that prove my fix is effective or that my feature works(The only feature that I added is the headless configuration property. Not really sure how to test it.)
- [x] I have added necessary documentation (if appropriate)