### PR TITLE
Fix for issue #614

### DIFF
--- a/src/main/java/com/codeborne/selenide/testng/SoftAsserts.java
+++ b/src/main/java/com/codeborne/selenide/testng/SoftAsserts.java
@@ -42,9 +42,18 @@ public class SoftAsserts extends ExitCodeListener {
     failIfErrors(result);
   }
 
+  @Override
+  public void beforeConfiguration(ITestResult result) {
+    addSelenideErrorListener(result);
+  }
+
   void addSelenideErrorListener(ITestResult result) {
-    if (shouldIntercept(result.getTestClass().getRealClass()) &&
-        shouldIntercept(result.getMethod().getConstructorOrMethod().getMethod())) {
+    boolean listenerAlreadyAdded = SelenideLogger.hasListener(LISTENER_SOFT_ASSERT);
+    boolean hasSoftAssertListener = shouldIntercept(result.getTestClass().getRealClass());
+    boolean isTestMethod = shouldIntercept(result.getMethod().getConstructorOrMethod().getMethod());
+    if (hasSoftAssertListener && isTestMethod && !listenerAlreadyAdded) {
+      SelenideLogger.addListener(LISTENER_SOFT_ASSERT, new ErrorsCollector());
+    } else if (hasSoftAssertListener && !listenerAlreadyAdded) {
       SelenideLogger.addListener(LISTENER_SOFT_ASSERT, new ErrorsCollector());
     }
   }


### PR DESCRIPTION
## Proposed changes
This pull request fixes issue [614](https://github.com/codeborne/selenide/issues/614).
The exception from the issue is thrown because the SoftAssert listener is added in the onTestStart() method, which is executed before all methods marked with @Test annotation. To be able to add that listener before configuration methods(e.g. @BeforeSuite, @BeforeMethod etc.) I added 
 beforeConfiguration() method from which  addSelenideErrorListener() method is called. I also modified the addSelenideErrorListener() method  a bit so th the SoftAssert listener would be added before executing any testng configuration methods and skip adding if that listener was already added. 

## Checklist
- [x ] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added necessary documentation (if appropriate)