### PR TITLE
#617 fix: Changed PageFactory to SelenidePageFactory in ElementsContainer's fields initialization

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/SelenideFieldDecorator.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideFieldDecorator.java
@@ -3,12 +3,12 @@ package com.codeborne.selenide.impl;
 import com.codeborne.selenide.ElementsCollection;
 import com.codeborne.selenide.ElementsContainer;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.SelenidePageFactory;
 import org.openqa.selenium.By;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.FindBys;
-import org.openqa.selenium.support.PageFactory;
 import org.openqa.selenium.support.pagefactory.Annotations;
 import org.openqa.selenium.support.pagefactory.DefaultElementLocatorFactory;
 import org.openqa.selenium.support.pagefactory.DefaultFieldDecorator;
@@ -75,7 +75,7 @@ public class SelenideFieldDecorator extends DefaultFieldDecorator {
     Constructor<?> constructor = type.getDeclaredConstructor();
     constructor.setAccessible(true);
     ElementsContainer result = (ElementsContainer) constructor.newInstance();
-    PageFactory.initElements(new SelenideFieldDecorator(self), result);
+    SelenidePageFactory.initElements(new SelenideFieldDecorator(self), result);
     result.setSelf(self);
     return result;
   }

--- a/src/test/java/integration/ElementsContainerWithManuallyInitializedFieldsTest.java
+++ b/src/test/java/integration/ElementsContainerWithManuallyInitializedFieldsTest.java
@@ -14,17 +14,18 @@ import static com.codeborne.selenide.Selenide.*;
 public class ElementsContainerWithManuallyInitializedFieldsTest extends IntegrationTest {
 
   @Before
-  public void openTestPage () {
+  public void openTestPage() {
     openFile("page_with_selects_without_jquery.html");
   }
 
   @Test
-  public void canInitializeElementsContainerFieldsWithoutFindByAnnotation () {
+  public void canInitializeElementsContainerFieldsWithoutFindByAnnotation() {
     MyPage page = page(MyPage.class);
 
     page.container.getSelf().should(exist, visible);
     page.container.headerLink.shouldHave(text("Options with 'apostrophes' and \"quotes\""));
-    page.container.options.shouldHave(texts("-- Select your hero --", "John Mc'Lain", "Arnold \"Schwarzenegger\"", "Mickey \"Rock'n'Roll\" Rourke"));
+    page.container.options.shouldHave(texts("-- Select your hero --", "John Mc'Lain", "Arnold \"Schwarzenegger\"",
+                                            "Mickey \"Rock'n'Roll\" Rourke"));
   }
 
 

--- a/src/test/java/integration/ElementsContainerWithManuallyInitializedFieldsTest.java
+++ b/src/test/java/integration/ElementsContainerWithManuallyInitializedFieldsTest.java
@@ -1,0 +1,40 @@
+package integration;
+
+import com.codeborne.selenide.ElementsCollection;
+import com.codeborne.selenide.ElementsContainer;
+import com.codeborne.selenide.SelenideElement;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.support.FindBy;
+
+import static com.codeborne.selenide.CollectionCondition.texts;
+import static com.codeborne.selenide.Condition.*;
+import static com.codeborne.selenide.Selenide.*;
+
+public class ElementsContainerWithManuallyInitializedFieldsTest extends IntegrationTest {
+
+  @Before
+  public void openTestPage () {
+    openFile("page_with_selects_without_jquery.html");
+  }
+
+  @Test
+  public void canInitializeElementsContainerFieldsWithoutFindByAnnotation () {
+    MyPage page = page(MyPage.class);
+
+    page.container.getSelf().should(exist, visible);
+    page.container.headerLink.shouldHave(text("Options with 'apostrophes' and \"quotes\""));
+    page.container.options.shouldHave(texts("-- Select your hero --", "John Mc'Lain", "Arnold \"Schwarzenegger\"", "Mickey \"Rock'n'Roll\" Rourke"));
+  }
+
+
+  private static class MyPage {
+    @FindBy (css = "#apostrophes-and-quotes")
+    MyContainer container;
+  }
+
+  private static class MyContainer extends ElementsContainer {
+    SelenideElement headerLink = $("h2>a");
+    ElementsCollection options = $$("#hero>option");
+  }
+}


### PR DESCRIPTION
## Proposed changes
#617 fix. 
Changed PageFactory to SelenidePageFactory in ElementsContainer's fields initialization what made Selenide not to re-init the fields that are already initialized.

**BUT** I realized that for now there is almost no sense in using not @FindBy in ElementsContainer because:
- If you do `SelenideElement el = $(...);` -> Selenide uses WebDriver as search context but not your container. So you have to specify locator which should include finding the parent element (container)
- `SelenideElement el = getSelf().$(...)` throws NPE just because `page(SomeContainer.class)` is called after the Container being instantiated itself. So self is null when `getSelf().$(...)` is called.
So probably that would be good to review the concept of ElementsContainer because there are too much nuances in it.

## Checklist
- [x] Checks passed locally
- [x] Test added