### PR TITLE
Actions before and after selenide commands, also, when command was executed with error.

### DIFF
--- a/src/main/java/com/codeborne/selenide/hookactions/HookAction.java
+++ b/src/main/java/com/codeborne/selenide/hookactions/HookAction.java
@@ -1,0 +1,25 @@
+package com.codeborne.selenide.hookactions;
+
+import org.openqa.selenium.WebElement;
+
+public interface HookAction {
+  /**
+   * Condition for activation
+   *
+   * @param element     WebElement
+   * @param methodName  Name of method, who called hook
+   * @param args        Called command arguments
+   * @return boolean
+   *
+   */
+  boolean conditionForAction(WebElement element, String methodName, Object... args);
+
+  /**
+   * Action, if conditionForAction is true
+   *
+   * @param element     WebElement
+   * @param methodName  Name of method, who called hook
+   * @param args        Called command arguments
+   */
+  void action(WebElement element, String methodName, Object... args);
+}

--- a/src/main/java/com/codeborne/selenide/hookactions/HookAction.java
+++ b/src/main/java/com/codeborne/selenide/hookactions/HookAction.java
@@ -12,10 +12,10 @@ public interface HookAction {
    * @return boolean
    *
    */
-  boolean conditionForAction(WebElement element, String methodName, Object... args);
+  boolean isActive(WebElement element, String methodName, Object... args);
 
   /**
-   * Action, if conditionForAction is true
+   * Action, if isActive is true
    *
    * @param element     WebElement
    * @param methodName  Name of method, who called hook

--- a/src/main/java/com/codeborne/selenide/hookactions/HookActions.java
+++ b/src/main/java/com/codeborne/selenide/hookactions/HookActions.java
@@ -1,0 +1,116 @@
+package com.codeborne.selenide.hookactions;
+
+import org.openqa.selenium.WebElement;
+
+import java.util.Collection;
+import java.util.HashMap;
+
+public class HookActions {
+  private static ThreadLocal<HookActions> instance = new ThreadLocal<>();
+  private HashMap<String, HookAction> beforeActions = new HashMap<>();
+  private HashMap<String, HookAction> afterActions = new HashMap<>();
+  private HashMap<String, HookAction> errorActions = new HashMap<>();
+
+  private HookActions() {
+  }
+
+  /**
+   *  Return instance of HookActions for current thread.
+   *
+   * @return HookActions
+   */
+  public static HookActions getInstance() {
+    if (instance() == null) {
+      instance.set(new HookActions());
+    }
+    return instance();
+  }
+
+  /**
+   * Run actions before command
+   *
+   * @param element     WebElement
+   * @param methodName  Name of method, who called hook
+   * @param args        Called command arguments
+   */
+  public void beforePreform(WebElement element, String methodName, Object... args) {
+    preform(element, methodName, beforeActions.values(), args);
+  }
+
+  /**
+   * Run actions after command
+   *
+   * @param element     WebElement
+   * @param methodName  Name of method, who called hook
+   * @param args        Called command arguments
+   */
+  public void afterPreform(WebElement element, String methodName, Object... args) {
+    preform(element, methodName, afterActions.values(), args);
+  }
+
+  /**
+   * Run action when command ends with error
+   *
+   * @param element     WebElement
+   * @param methodName  Name of method, who called hook
+   * @param args        Called command arguments
+   */
+  public void errorPreform(WebElement element, String methodName, Object... args) {
+    preform(element, methodName, errorActions.values(), args);
+  }
+
+  /**
+   * Register new before action
+   *
+   * @param name    Name of registered hook
+   * @param action  HookAction implementation
+   */
+  public void addBeforeAction(String name, HookAction action) {
+    instance.get().beforeActions.put(name, action);
+  }
+
+  /**
+   * Register new after action
+   *
+   * @param name    Name of registered hook
+   * @param action  HookAction implementation
+   */
+  public void addAfterAction(String name, HookAction action) {
+    instance.get().afterActions.put(name, action);
+  }
+
+  /**
+   * Register new error action
+   *
+   * @param name    Name of registered hook
+   * @param action  HookAction implementation
+   */
+  public void addErrorAction(String name, HookAction action) {
+    instance.get().errorActions.put(name, action);
+  }
+
+  /**
+   * Remove action from HookActions
+   * Try to remove from before, after and error actions lists.
+   *
+   * @param name    Name of hook to remove
+   */
+  public void removeAction(String name) {
+    if (instance.get().beforeActions.containsKey(name))
+      instance.get().beforeActions.remove(name);
+    if (instance.get().afterActions.containsKey(name))
+      instance.get().afterActions.remove(name);
+    if (instance.get().errorActions.containsKey(name))
+      instance.get().errorActions.remove(name);
+  }
+
+  private static HookActions instance() {
+    return instance.get();
+  }
+
+  private void preform(WebElement element, String methodName, Collection<HookAction> actions, Object... args) {
+    for (HookAction action : actions) {
+      if (action.conditionForAction(element, methodName, args)) action.action(element, methodName, args);
+    }
+  }
+}

--- a/src/main/java/com/codeborne/selenide/hookactions/HookActions.java
+++ b/src/main/java/com/codeborne/selenide/hookactions/HookActions.java
@@ -33,8 +33,8 @@ public class HookActions {
    * @param methodName  Name of method, who called hook
    * @param args        Called command arguments
    */
-  public void beforePreform(WebElement element, String methodName, Object... args) {
-    preform(element, methodName, beforeActions.values(), args);
+  public void beforePerform(WebElement element, String methodName, Object... args) {
+    perform(element, methodName, beforeActions.values(), args);
   }
 
   /**
@@ -44,8 +44,8 @@ public class HookActions {
    * @param methodName  Name of method, who called hook
    * @param args        Called command arguments
    */
-  public void afterPreform(WebElement element, String methodName, Object... args) {
-    preform(element, methodName, afterActions.values(), args);
+  public void afterPerform(WebElement element, String methodName, Object... args) {
+    perform(element, methodName, afterActions.values(), args);
   }
 
   /**
@@ -55,8 +55,8 @@ public class HookActions {
    * @param methodName  Name of method, who called hook
    * @param args        Called command arguments
    */
-  public void errorPreform(WebElement element, String methodName, Object... args) {
-    preform(element, methodName, errorActions.values(), args);
+  public void errorPerform(WebElement element, String methodName, Object... args) {
+    perform(element, methodName, errorActions.values(), args);
   }
 
   /**
@@ -90,27 +90,39 @@ public class HookActions {
   }
 
   /**
-   * Remove action from HookActions
-   * Try to remove from before, after and error actions lists.
+   * Remove action from before HookActions list
    *
    * @param name    Name of hook to remove
    */
-  public void removeAction(String name) {
-    if (instance.get().beforeActions.containsKey(name))
-      instance.get().beforeActions.remove(name);
-    if (instance.get().afterActions.containsKey(name))
-      instance.get().afterActions.remove(name);
-    if (instance.get().errorActions.containsKey(name))
-      instance.get().errorActions.remove(name);
+  public void removeBeforeAction(String name) {
+    instance.get().beforeActions.remove(name);
+  }
+
+  /**
+   * Remove action from after HookActions list
+   *
+   * @param name    Name of hook to remove
+   */
+  public void removeAfterAction(String name) {
+    instance.get().afterActions.remove(name);
+  }
+
+  /**
+   * Remove action from error HookActions list
+   *
+   * @param name    Name of hook to remove
+   */
+  public void removeErrorAction(String name) {
+    instance.get().errorActions.remove(name);
   }
 
   private static HookActions instance() {
     return instance.get();
   }
 
-  private void preform(WebElement element, String methodName, Collection<HookAction> actions, Object... args) {
+  private void perform(WebElement element, String methodName, Collection<HookAction> actions, Object... args) {
     for (HookAction action : actions) {
-      if (action.conditionForAction(element, methodName, args)) action.action(element, methodName, args);
+      if (action.isActive(element, methodName, args)) action.action(element, methodName, args);
     }
   }
 }

--- a/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
@@ -61,23 +61,23 @@ class SelenideElementProxy implements InvocationHandler {
     long timeoutMs = getTimeoutMs(method, args);
     long pollingIntervalMs = getPollingIntervalMs(method, args);
     SelenideLog log = SelenideLogger.beginStep(webElementSource.getSearchCriteria(), method.getName(), args);
-    HookActions.getInstance().beforePreform((WebElement) proxy, method.getName(), args);
+    HookActions.getInstance().beforePerform((WebElement) proxy, method.getName(), args);
     try {
       Object result = dispatchAndRetry(timeoutMs, pollingIntervalMs, proxy, method, args);
       SelenideLogger.commitStep(log, PASS);
-      HookActions.getInstance().afterPreform((WebElement) proxy, method.getName(), args);
+      HookActions.getInstance().afterPerform((WebElement) proxy, method.getName(), args);
       return result;
     }
     catch (Error error) {
       SelenideLogger.commitStep(log, error);
-      HookActions.getInstance().errorPreform((WebElement) proxy, method.getName(), args);
+      HookActions.getInstance().errorPerform((WebElement) proxy, method.getName(), args);
       if (assertionMode == SOFT && methodsForSoftAssertion.contains(method.getName()))
         return proxy;
       else
         throw UIAssertionError.wrap(error, timeoutMs);
     }
     catch (RuntimeException error) {
-      HookActions.getInstance().errorPreform((WebElement) proxy, method.getName(), args);
+      HookActions.getInstance().errorPerform((WebElement) proxy, method.getName(), args);
       SelenideLogger.commitStep(log, error);
       throw error;
     }

--- a/src/test/java/com/codeborne/selenide/HookActionsTest.java
+++ b/src/test/java/com/codeborne/selenide/HookActionsTest.java
@@ -1,0 +1,123 @@
+package com.codeborne.selenide;
+
+import com.codeborne.selenide.hookactions.HookAction;
+import com.codeborne.selenide.hookactions.HookActions;
+import org.junit.After;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class HookActionsTest {
+  String catchAction = "";
+
+  @After
+  public void cleanUp() {
+    HookActions.getInstance().removeAction("testHook");
+    catchAction = "";
+  }
+
+  @Test
+  public void preformBeforeHook() {
+    HookActions.getInstance().addBeforeAction("testHook", new TestAction("Before action", true));
+    HookActions.getInstance().beforePreform(null, "command");
+    assertThat("Before action error", catchAction.equals("Before action"), is(true));
+  }
+
+  @Test
+  public void preformAfterHook() {
+    HookActions.getInstance().addAfterAction("testHook", new TestAction("After action", true));
+    HookActions.getInstance().afterPreform(null, "command");
+    assertThat("After action error", catchAction.equals("After action"), is(true));
+  }
+
+  @Test
+  public void preformErrorHook() {
+    HookActions.getInstance().addErrorAction("testHook", new TestAction("Error action", true));
+    HookActions.getInstance().errorPreform(null, "command");
+    assertThat("Error action error", catchAction.equals("Error action"), is(true));
+  }
+
+  @Test
+  public void preformNotActivateHook() {
+    HookActions.getInstance().addBeforeAction("testHook", new TestAction("Unactivated action", false));
+    HookActions.getInstance().beforePreform(null, "command");
+    assertThat("Call Unactivated Action", catchAction.equals(""), is(true));
+  }
+
+  @Test
+  public void removeBeforeHook() {
+    HookActions.getInstance().addBeforeAction("testHook", new TestAction("Removed Before action", true));
+    HookActions.getInstance().removeAction("testHook");
+    HookActions.getInstance().beforePreform(null, "command");
+    assertThat("Removed Before action called", catchAction.equals(""), is(true));
+  }
+
+  @Test
+  public void removeAfterHook() {
+    HookActions.getInstance().addAfterAction("testHook", new TestAction("Removed After action", true));
+    HookActions.getInstance().removeAction("testHook");
+    HookActions.getInstance().afterPreform(null, "command");
+    assertThat("Removed After action called", catchAction.equals(""), is(true));
+  }
+
+  @Test
+  public void removeErrorHook() {
+    HookActions.getInstance().addErrorAction("testHook", new TestAction("Removed error action", true));
+    HookActions.getInstance().removeAction("testHook");
+    HookActions.getInstance().errorPreform(null, "command");
+    assertThat("Removed Error action called", catchAction.equals(""), is(true));
+  }
+
+  @Test
+  public void preformTwoHooks() {
+    HookActions.getInstance().addBeforeAction("testHook", new TestAction("hook1", true));
+    HookActions.getInstance().addBeforeAction("testHook1", new TestAction("hook2", true));
+    HookActions.getInstance().beforePreform(null, "command");
+    assertThat("Two actions error", catchAction.equals("hook1hook2"), is(true));
+    HookActions.getInstance().removeAction("testHook");
+    HookActions.getInstance().removeAction("testHook1");
+  }
+
+  @Test
+  public void preformHookWithCommandArgs() {
+    HookActions.getInstance().addBeforeAction("testHook", new TestActionWithCommandArgs("testHook", true));
+    HookActions.getInstance().beforePreform(null, "command", "one", "two", "three");
+    assertThat("Hook with command args usage", catchAction.equals("onetwothree"), is(true));
+  }
+
+  class TestAction implements HookAction {
+    private String testString;
+    private boolean isActive;
+
+    public TestAction(String testString, boolean isActive) {
+      this.testString = testString;
+      this.isActive = isActive;
+    }
+
+    @Override
+    public boolean conditionForAction(WebElement element, String methodName, Object... args) {
+      return isActive;
+    }
+
+    @Override
+    public void action(WebElement element, String methodName, Object... args) {
+      catchAction += testString;
+    }
+  }
+
+  class TestActionWithCommandArgs extends TestAction {
+
+    public TestActionWithCommandArgs(String testString, boolean isActive) {
+      super(testString, isActive);
+    }
+
+    @Override
+    public void action(WebElement element, String methodName, Object... args) {
+      for (Object arg: args) {
+        catchAction += (String) arg;
+      }
+    }
+  }
+}

--- a/src/test/java/com/codeborne/selenide/HookActionsTest.java
+++ b/src/test/java/com/codeborne/selenide/HookActionsTest.java
@@ -14,59 +14,61 @@ public class HookActionsTest {
 
   @After
   public void cleanUp() {
-    HookActions.getInstance().removeAction("testHook");
+    HookActions.getInstance().removeBeforeAction("testHook");
+    HookActions.getInstance().removeAfterAction("testHook");
+    HookActions.getInstance().removeErrorAction("testHook");
     catchAction = "";
   }
 
   @Test
   public void preformBeforeHook() {
     HookActions.getInstance().addBeforeAction("testHook", new TestAction("Before action", true));
-    HookActions.getInstance().beforePreform(null, "command");
+    HookActions.getInstance().beforePerform(null, "command");
     assertThat("Before action error", catchAction.equals("Before action"), is(true));
   }
 
   @Test
   public void preformAfterHook() {
     HookActions.getInstance().addAfterAction("testHook", new TestAction("After action", true));
-    HookActions.getInstance().afterPreform(null, "command");
+    HookActions.getInstance().afterPerform(null, "command");
     assertThat("After action error", catchAction.equals("After action"), is(true));
   }
 
   @Test
   public void preformErrorHook() {
     HookActions.getInstance().addErrorAction("testHook", new TestAction("Error action", true));
-    HookActions.getInstance().errorPreform(null, "command");
+    HookActions.getInstance().errorPerform(null, "command");
     assertThat("Error action error", catchAction.equals("Error action"), is(true));
   }
 
   @Test
   public void preformNotActivateHook() {
     HookActions.getInstance().addBeforeAction("testHook", new TestAction("Unactivated action", false));
-    HookActions.getInstance().beforePreform(null, "command");
+    HookActions.getInstance().beforePerform(null, "command");
     assertThat("Call Unactivated Action", catchAction.equals(""), is(true));
   }
 
   @Test
   public void removeBeforeHook() {
     HookActions.getInstance().addBeforeAction("testHook", new TestAction("Removed Before action", true));
-    HookActions.getInstance().removeAction("testHook");
-    HookActions.getInstance().beforePreform(null, "command");
+    HookActions.getInstance().removeBeforeAction("testHook");
+    HookActions.getInstance().beforePerform(null, "command");
     assertThat("Removed Before action called", catchAction.equals(""), is(true));
   }
 
   @Test
   public void removeAfterHook() {
     HookActions.getInstance().addAfterAction("testHook", new TestAction("Removed After action", true));
-    HookActions.getInstance().removeAction("testHook");
-    HookActions.getInstance().afterPreform(null, "command");
+    HookActions.getInstance().removeAfterAction("testHook");
+    HookActions.getInstance().afterPerform(null, "command");
     assertThat("Removed After action called", catchAction.equals(""), is(true));
   }
 
   @Test
   public void removeErrorHook() {
     HookActions.getInstance().addErrorAction("testHook", new TestAction("Removed error action", true));
-    HookActions.getInstance().removeAction("testHook");
-    HookActions.getInstance().errorPreform(null, "command");
+    HookActions.getInstance().removeErrorAction("testHook");
+    HookActions.getInstance().errorPerform(null, "command");
     assertThat("Removed Error action called", catchAction.equals(""), is(true));
   }
 
@@ -74,16 +76,15 @@ public class HookActionsTest {
   public void preformTwoHooks() {
     HookActions.getInstance().addBeforeAction("testHook", new TestAction("hook1", true));
     HookActions.getInstance().addBeforeAction("testHook1", new TestAction("hook2", true));
-    HookActions.getInstance().beforePreform(null, "command");
+    HookActions.getInstance().beforePerform(null, "command");
     assertThat("Two actions error", catchAction.equals("hook1hook2"), is(true));
-    HookActions.getInstance().removeAction("testHook");
-    HookActions.getInstance().removeAction("testHook1");
+    HookActions.getInstance().removeBeforeAction("testHook1");
   }
 
   @Test
   public void preformHookWithCommandArgs() {
     HookActions.getInstance().addBeforeAction("testHook", new TestActionWithCommandArgs("testHook", true));
-    HookActions.getInstance().beforePreform(null, "command", "one", "two", "three");
+    HookActions.getInstance().beforePerform(null, "command", "one", "two", "three");
     assertThat("Hook with command args usage", catchAction.equals("onetwothree"), is(true));
   }
 
@@ -97,7 +98,7 @@ public class HookActionsTest {
     }
 
     @Override
-    public boolean conditionForAction(WebElement element, String methodName, Object... args) {
+    public boolean isActive(WebElement element, String methodName, Object... args) {
       return isActive;
     }
 

--- a/src/test/java/com/codeborne/selenide/HookActionsTest.java
+++ b/src/test/java/com/codeborne/selenide/HookActionsTest.java
@@ -91,7 +91,7 @@ public class HookActionsTest {
     private String testString;
     private boolean isActive;
 
-    public TestAction(String testString, boolean isActive) {
+    TestAction(String testString, boolean isActive) {
       this.testString = testString;
       this.isActive = isActive;
     }
@@ -109,7 +109,7 @@ public class HookActionsTest {
 
   class TestActionWithCommandArgs extends TestAction {
 
-    public TestActionWithCommandArgs(String testString, boolean isActive) {
+    TestActionWithCommandArgs(String testString, boolean isActive) {
       super(testString, isActive);
     }
 

--- a/src/test/java/demo/hookactions/DemoAction.java
+++ b/src/test/java/demo/hookactions/DemoAction.java
@@ -1,0 +1,34 @@
+package demo.hookactions;
+
+import com.codeborne.selenide.hookactions.HookAction;
+import org.openqa.selenium.WebElement;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.codeborne.selenide.Selenide.$;
+import static java.util.Arrays.asList;
+
+public class DemoAction implements HookAction {
+  private String suffix;
+
+  protected static final Set<String> hoockedActions = new HashSet<>(asList(
+          "click",
+          "doubleClick"
+  ));
+
+  public DemoAction(String suffix) {
+    this.suffix = suffix;
+  }
+
+  @Override
+  public boolean conditionForAction(WebElement element, String methodName, Object... args) {
+    return hoockedActions.contains(methodName);
+  }
+
+  @Override
+  public void action(WebElement element, String methodName, Object... args) {
+    String locator = $(element).getSearchCriteria();
+    System.out.println(String.format("%s %s%s", locator, methodName, suffix));
+  }
+}

--- a/src/test/java/demo/hookactions/DemoAction.java
+++ b/src/test/java/demo/hookactions/DemoAction.java
@@ -22,7 +22,7 @@ public class DemoAction implements HookAction {
   }
 
   @Override
-  public boolean conditionForAction(WebElement element, String methodName, Object... args) {
+  public boolean isActive(WebElement element, String methodName, Object... args) {
     return hoockedActions.contains(methodName);
   }
 

--- a/src/test/java/demo/hookactions/HookActionsDemo.java
+++ b/src/test/java/demo/hookactions/HookActionsDemo.java
@@ -1,0 +1,34 @@
+package demo.hookactions;
+
+import com.codeborne.selenide.ElementsCollection;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.hookactions.HookActions;
+
+import java.net.URL;
+
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.$$;
+import static com.codeborne.selenide.Selenide.open;
+
+public class HookActionsDemo {
+
+  public static void main(String[] args) throws InterruptedException {
+    URL url = HookActionsDemo.class.getResource("/page_with_big_divs.html");
+
+    HookActions.getInstance().addBeforeAction("beforeDemo", new DemoAction("ing"));
+    HookActions.getInstance().addAfterAction("afterDemo", new DemoAction("ed"));
+    HookActions.getInstance().addErrorAction("errorDemo", new DemoAction(" failed"));
+
+    open(url);
+    ElementsCollection collection = $$("div");
+    for (SelenideElement e : collection) {
+      e.click();
+    }
+
+    for (SelenideElement e : collection) {
+      e.doubleClick();
+    }
+
+    $("div.these.are.not.droid.what.you.looking.for").click();
+  }
+}

--- a/src/test/java/demo/hookactions/HookActionsDemo.java
+++ b/src/test/java/demo/hookactions/HookActionsDemo.java
@@ -14,7 +14,6 @@ public class HookActionsDemo {
 
   public static void main(String[] args) throws InterruptedException {
     URL url = HookActionsDemo.class.getResource("/page_with_big_divs.html");
-
     HookActions.getInstance().addBeforeAction("beforeDemo", new DemoAction("ing"));
     HookActions.getInstance().addAfterAction("afterDemo", new DemoAction("ed"));
     HookActions.getInstance().addErrorAction("errorDemo", new DemoAction(" failed"));

--- a/src/test/java/integration/HookActionsTest.java
+++ b/src/test/java/integration/HookActionsTest.java
@@ -1,0 +1,96 @@
+package integration;
+
+import com.codeborne.selenide.hookactions.HookAction;
+import com.codeborne.selenide.hookactions.HookActions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import static com.codeborne.selenide.Selenide.$;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class HookActionsTest  extends IntegrationTest {
+  String catchAction = "";
+
+  @Before
+  public void setUp() {
+    openFile("page_with_big_divs.html");
+  }
+
+  @After
+  public void cleanUp() {
+    HookActions.getInstance().removeAction("testHook");
+    catchAction = "";
+  }
+
+  @Test
+  public void beforeActionTest() {
+    HookActions.getInstance().addBeforeAction("testHook", new TestAction(true));
+    $("div", 0).click();
+    assertThat("Before action error", catchAction.equals("click"), is(true));
+  }
+
+  @Test
+  public void afterActionTest() {
+    HookActions.getInstance().addAfterAction("testHook", new TestAction(true));
+    $("div", 0).click();
+    assertThat("After action error", catchAction.equals("click"), is(true));
+  }
+
+  @Test
+  public void errorActionTest() {
+    HookActions.getInstance().addErrorAction("testHook", new TestAction(true));
+    try {
+      $("div.these.are.not.droid.what.you.looking.for").click();
+    } catch (Throwable e) { }
+    assertThat("Error action error", catchAction.equals("click"), is(true));
+  }
+
+  @Test
+  public void twoActionsTest() {
+    HookActions.getInstance().addBeforeAction("testHook", new TestAction(true));
+    HookActions.getInstance().addAfterAction("testHook", new TestAction(true));
+    $("div", 0).click();
+    assertThat("After action error", catchAction.equals("clickclick"), is(true));
+  }
+
+  @Test
+  public void actionsWithArgsTest() {
+    HookActions.getInstance().addBeforeAction("testHook", new TestActionWithArgs());
+    $("div", 0).getAttribute("id");
+    assertThat("Action with args error", catchAction.equals("id"), is(true));
+  }
+
+  class TestAction implements HookAction {
+    private boolean isActive;
+
+    public TestAction(boolean isActive) {
+      this.isActive = isActive;
+    }
+
+    @Override
+    public boolean conditionForAction(WebElement element, String methodName, Object... args) {
+      return isActive;
+    }
+
+    @Override
+    public void action(WebElement element, String methodName, Object... args) {
+      catchAction += methodName;
+    }
+  }
+
+  class TestActionWithArgs implements HookAction {
+
+    @Override
+    public boolean conditionForAction(WebElement element, String methodName, Object... args) {
+      return true;
+    }
+
+    @Override
+    public void action(WebElement element, String methodName, Object... args) {
+      catchAction += args[0].toString();
+    }
+  }
+}

--- a/src/test/java/integration/HookActionsTest.java
+++ b/src/test/java/integration/HookActionsTest.java
@@ -21,21 +21,23 @@ public class HookActionsTest  extends IntegrationTest {
 
   @After
   public void cleanUp() {
-    HookActions.getInstance().removeAction("testHook");
+    HookActions.getInstance().removeBeforeAction("testHook");
+    HookActions.getInstance().removeAfterAction("testHook");
+    HookActions.getInstance().removeErrorAction("testHook");
     catchAction = "";
   }
 
   @Test
   public void beforeActionTest() {
     HookActions.getInstance().addBeforeAction("testHook", new TestAction(true));
-    $("div", 0).click();
+    $("h1").click();
     assertThat("Before action error", catchAction.equals("click"), is(true));
   }
 
   @Test
   public void afterActionTest() {
     HookActions.getInstance().addAfterAction("testHook", new TestAction(true));
-    $("div", 0).click();
+    $("h1").click();
     assertThat("After action error", catchAction.equals("click"), is(true));
   }
 
@@ -52,7 +54,7 @@ public class HookActionsTest  extends IntegrationTest {
   public void twoActionsTest() {
     HookActions.getInstance().addBeforeAction("testHook", new TestAction(true));
     HookActions.getInstance().addAfterAction("testHook", new TestAction(true));
-    $("div", 0).click();
+    $("h1").click();
     assertThat("After action error", catchAction.equals("clickclick"), is(true));
   }
 
@@ -71,7 +73,7 @@ public class HookActionsTest  extends IntegrationTest {
     }
 
     @Override
-    public boolean conditionForAction(WebElement element, String methodName, Object... args) {
+    public boolean isActive(WebElement element, String methodName, Object... args) {
       return isActive;
     }
 
@@ -84,7 +86,7 @@ public class HookActionsTest  extends IntegrationTest {
   class TestActionWithArgs implements HookAction {
 
     @Override
-    public boolean conditionForAction(WebElement element, String methodName, Object... args) {
+    public boolean isActive(WebElement element, String methodName, Object... args) {
       return true;
     }
 

--- a/src/test/java/integration/HookActionsTest.java
+++ b/src/test/java/integration/HookActionsTest.java
@@ -66,7 +66,7 @@ public class HookActionsTest  extends IntegrationTest {
   class TestAction implements HookAction {
     private boolean isActive;
 
-    public TestAction(boolean isActive) {
+    TestAction(boolean isActive) {
       this.isActive = isActive;
     }
 


### PR DESCRIPTION
Here impemened some kind of before/after action hooks(requested https://github.com/codeborne/selenide/issues/447)

For this just implement HookAction interface. Then register your action with
`HookActions.getInstance().addBeforeAction(String name, HookAction action)`
This actions will be executed before executing selenide command.

or
`HookActions.getInstance().addAfterAction(String name, HookAction action)`
This actions will be executed after successfully finished selenide command i.e without any exceptions.

or
`HookActions.getInstance().addErrorAction(String name, HookAction action)`
This actions will be executed after falied selenide command right before throwing exception.

Also i added demo and tests for new feature.
And add empty line in the end of src/test/java/com/codeborne/selenide/webdriver/RemoteDriverFactoryTest.java 
About that code style checker was complained.