### PR TITLE
Add ability to set browser binary path using configuration parameter.

### DIFF
--- a/src/main/java/com/codeborne/selenide/Configuration.java
+++ b/src/main/java/com/codeborne/selenide/Configuration.java
@@ -365,4 +365,10 @@ public class Configuration {
    * Default: false
    */
   public static boolean headless = Boolean.parseBoolean(System.getProperty("selenide.headless", "false"));
+
+  /**
+   * Sets the path to browser executable.
+   * Works only for Chrome, Firefox and Opera.
+   */
+  public static String browserBinary = System.getProperty("selenide.browserBinary", "");
 }

--- a/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
@@ -29,7 +29,9 @@ class ChromeDriverFactory extends AbstractDriverFactory {
   ChromeOptions createChromeOptions(Proxy proxy) {
     ChromeOptions options = new ChromeOptions();
     options.setHeadless(headless);
-    options.setBinary(browserBinary);
+    if (!browserBinary.isEmpty()) {
+      options.setBinary(browserBinary);
+    }
     options.addArguments("--no-sandbox");  // This make Chromium reachable (?)
     if (chromeSwitches != null) {
       options.addArguments(chromeSwitches);

--- a/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
@@ -29,6 +29,7 @@ class ChromeDriverFactory extends AbstractDriverFactory {
   ChromeOptions createChromeOptions(Proxy proxy) {
     ChromeOptions options = new ChromeOptions();
     options.setHeadless(headless);
+    options.setBinary(browserBinary);
     options.addArguments("--no-sandbox");  // This make Chromium reachable (?)
     if (chromeSwitches != null) {
       options.addArguments(chromeSwitches);

--- a/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
@@ -3,12 +3,10 @@ package com.codeborne.selenide.webdriver;
 import com.codeborne.selenide.WebDriverRunner;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.firefox.FirefoxBinary;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
 
-import java.io.File;
 import java.util.logging.Logger;
 
 import static com.codeborne.selenide.Configuration.browserBinary;

--- a/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
@@ -9,6 +9,7 @@ import org.openqa.selenium.firefox.FirefoxProfile;
 
 import java.util.logging.Logger;
 
+import static com.codeborne.selenide.Configuration.browserBinary;
 import static com.codeborne.selenide.Configuration.headless;
 
 class FirefoxDriverFactory extends AbstractDriverFactory {
@@ -33,6 +34,7 @@ class FirefoxDriverFactory extends AbstractDriverFactory {
   FirefoxOptions createFirefoxOptions(Proxy proxy) {
     FirefoxOptions firefoxOptions = new FirefoxOptions();
     firefoxOptions.setHeadless(headless);
+    firefoxOptions.setBinary(browserBinary);
     firefoxOptions.addPreference("network.automatic-ntlm-auth.trusted-uris", "http://,https://");
     firefoxOptions.addPreference("network.automatic-ntlm-auth.allow-non-fqdn", true);
     firefoxOptions.addPreference("network.negotiate-auth.delegation-uris", "http://,https://");

--- a/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
@@ -3,10 +3,12 @@ package com.codeborne.selenide.webdriver;
 import com.codeborne.selenide.WebDriverRunner;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.firefox.FirefoxBinary;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
 
+import java.io.File;
 import java.util.logging.Logger;
 
 import static com.codeborne.selenide.Configuration.browserBinary;
@@ -34,7 +36,9 @@ class FirefoxDriverFactory extends AbstractDriverFactory {
   FirefoxOptions createFirefoxOptions(Proxy proxy) {
     FirefoxOptions firefoxOptions = new FirefoxOptions();
     firefoxOptions.setHeadless(headless);
-    firefoxOptions.setBinary(browserBinary);
+    if (!browserBinary.isEmpty()) {
+      firefoxOptions.setBinary(browserBinary);
+    }
     firefoxOptions.addPreference("network.automatic-ntlm-auth.trusted-uris", "http://,https://");
     firefoxOptions.addPreference("network.automatic-ntlm-auth.allow-non-fqdn", true);
     firefoxOptions.addPreference("network.negotiate-auth.delegation-uris", "http://,https://");

--- a/src/main/java/com/codeborne/selenide/webdriver/OperaDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/OperaDriverFactory.java
@@ -22,7 +22,9 @@ class OperaDriverFactory extends AbstractDriverFactory {
 
   private WebDriver createOperaDriver(final Proxy proxy) {
     OperaOptions operaOptions = new OperaOptions();
-    operaOptions.setBinary(browserBinary);
+    if (!browserBinary.isEmpty()) {
+      operaOptions.setBinary(browserBinary);
+    }
     operaOptions.merge(createCommonCapabilities(proxy));
     return new OperaDriver(operaOptions);
   }

--- a/src/main/java/com/codeborne/selenide/webdriver/OperaDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/OperaDriverFactory.java
@@ -6,6 +6,8 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.opera.OperaDriver;
 import org.openqa.selenium.opera.OperaOptions;
 
+import static com.codeborne.selenide.Configuration.browserBinary;
+
 class OperaDriverFactory extends AbstractDriverFactory {
 
   @Override
@@ -20,6 +22,7 @@ class OperaDriverFactory extends AbstractDriverFactory {
 
   private WebDriver createOperaDriver(final Proxy proxy) {
     OperaOptions operaOptions = new OperaOptions();
+    operaOptions.setBinary(browserBinary);
     operaOptions.merge(createCommonCapabilities(proxy));
     return new OperaDriver(operaOptions);
   }


### PR DESCRIPTION
## Proposed changes
Sometimes there is a need to run some tests locally using different browser version. To do that you need to explicitly set browser binary path. These changes add a "browserBinary" parameter which can be used to set browser executable path. Works only for Firefox, Chrome and Opera, since other browsers don't support custom binary path.

## Checklist
- [x ] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added necessary documentation (if appropriate)