### PR TITLE
Add new condition to check condition on child

### DIFF
--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -4,9 +4,11 @@ import com.codeborne.selenide.conditions.Text;
 import com.codeborne.selenide.impl.Describe;
 import com.codeborne.selenide.impl.Html;
 import com.google.common.base.Predicate;
+import org.openqa.selenium.By;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 
+import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.getFocusedElement;
 
 /**
@@ -562,6 +564,23 @@ public abstract class Condition implements Predicate<WebElement> {
       @Override
       public String toString() {
         return firstFailedCondition == null ? super.toString() : firstFailedCondition.toString();
+      }
+    };
+  }
+
+  /**
+   * Used to apply a condition on a child of the element
+   * Example element.child("span", have(text("abc"))
+   * @param childCssSelector the CSS selector of the child inside the element
+   * @param condition the condition to check on this child
+   * @return
+   */
+  public static Condition child(final String childCssSelector, final Condition condition) {
+    return new Condition("child " + childCssSelector + " has " + condition.name) {
+      @Override
+      public boolean apply(WebElement element) {
+        SelenideElement child = $(element.findElement(By.cssSelector(childCssSelector)));
+        return child.has(condition);
       }
     };
   }

--- a/src/test/java/com/codeborne/selenide/ConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/ConditionTest.java
@@ -1,8 +1,11 @@
 package com.codeborne.selenide;
 
 import org.junit.Test;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
@@ -217,6 +220,31 @@ public class ConditionTest {
     assertTrue(Condition.or("Visible, not Selected",
         Condition.visible,
         Condition.checked).apply(element));
+  }
+
+  @Test
+  public void elementChild() {
+    WebDriver driver = new HtmlUnitDriver(true);
+    driver.get("about:blank");
+    JavascriptExecutor js = (JavascriptExecutor) driver;
+    WebElement parent = (WebElement) js.executeScript(
+        "parent = document.createElement('div');"
+            + "child = document.createElement('div');"
+            + "parent.innerHTML = 'parent';"
+            + "child.innerHTML = 'child';"
+            + "parent.appendChild(child);"
+            + "document.body.appendChild(parent);"
+            + "return parent;"
+    );
+
+    assertTrue(Condition.child("div", Condition.text("child")).apply(parent));
+    assertFalse(Condition.child("div", Condition.text("parent")).apply(parent));
+  }
+
+  @Test
+  public void conditionChild() {
+    Condition condition = Condition.child("div", Condition.visible);
+    assertEquals("child div has visible", condition.toString());
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/ConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/ConditionTest.java
@@ -223,25 +223,6 @@ public class ConditionTest {
   }
 
   @Test
-  public void elementChild() {
-    WebDriver driver = new HtmlUnitDriver(true);
-    driver.get("about:blank");
-    JavascriptExecutor js = (JavascriptExecutor) driver;
-    WebElement parent = (WebElement) js.executeScript(
-        "parent = document.createElement('div');"
-            + "child = document.createElement('div');"
-            + "parent.innerHTML = 'parent';"
-            + "child.innerHTML = 'child';"
-            + "parent.appendChild(child);"
-            + "document.body.appendChild(parent);"
-            + "return parent;"
-    );
-
-    assertTrue(Condition.child("div", Condition.text("child")).apply(parent));
-    assertFalse(Condition.child("div", Condition.text("parent")).apply(parent));
-  }
-
-  @Test
   public void conditionChild() {
     Condition condition = Condition.child("div", Condition.visible);
     assertEquals("child div has visible", condition.toString());

--- a/src/test/java/com/codeborne/selenide/ConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/ConditionTest.java
@@ -1,11 +1,8 @@
 package com.codeborne.selenide;
 
 import org.junit.Test;
-import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.StaleElementReferenceException;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
@@ -22,7 +19,7 @@ public class ConditionTest {
   @Test
   public void textConditionChecksForSubstring() {
     assertTrue(Condition.text("John Malkovich The First").apply(elementWithText("John Malkovich The First")));
-    
+
     assertFalse(Condition.text("John Malkovich First").apply(elementWithText("John Malkovich The First")));
     assertFalse(Condition.text("john bon jovi").apply(elementWithText("John Malkovich The First")));
   }
@@ -32,12 +29,12 @@ public class ConditionTest {
     WebElement element = elementWithText("John Malkovich The First");
     assertTrue(Condition.text("john malkovich").apply(element));
   }
-  
+
   @Test
   public void textConditionIgnoresWhitespaces() {
     assertTrue(Condition.text("john the malkovich").apply(
         elementWithText("John  the\n Malkovich")));
-    
+
     assertTrue(Condition.text("This is nonbreakable space").apply(
         elementWithText("This is nonbreakable\u00a0space")));
   }
@@ -81,7 +78,7 @@ public class ConditionTest {
     assertTrue(Condition.value("John Malkovich").apply(element));
     assertTrue(Condition.value("malko").apply(element));
   }
-  
+
   @Test
   public void elementIsVisible() {
     assertTrue(Condition.visible.apply(elementWithVisibility(true)));
@@ -93,7 +90,7 @@ public class ConditionTest {
     assertTrue(Condition.exist.apply(elementWithVisibility(true)));
     assertTrue(Condition.exist.apply(elementWithVisibility(false)));
   }
-  
+
   @Test
   public void elementExists_returnsFalse_ifItThrowsException() {
     WebElement element = mock(WebElement.class);
@@ -216,7 +213,7 @@ public class ConditionTest {
   public void elementVisibleButNotSelected() {
     WebElement element = elementWithVisibility(true);
     when(element.isSelected()).thenReturn(false);
-    
+
     assertTrue(Condition.or("Visible, not Selected",
         Condition.visible,
         Condition.checked).apply(element));

--- a/src/test/java/integration/CollectionMethodsTest.java
+++ b/src/test/java/integration/CollectionMethodsTest.java
@@ -130,6 +130,14 @@ public class CollectionMethodsTest extends IntegrationTest {
   }
 
   @Test
+  public void userCanFilterElementsByConditionOnChild() {
+    ElementsCollection collectionToFilter = $$("#multirowTable tr");
+    ElementsCollection collectionFiltered = collectionToFilter.filterBy(child("td:nth-child(2)", text("Norris")));
+    collectionToFilter.shouldHaveSize(2);
+    collectionFiltered.shouldHaveSize(1);
+  }
+
+  @Test
   public void userCanExcludeMatchingElements() {
     $$("#multirowTable tr").shouldHaveSize(2);
     $$("#multirowTable tr").excludeWith(text("Chack")).shouldHaveSize(0);


### PR DESCRIPTION
## Proposed changes

I added a condition that allow to apply another condition on a child of the element.

As I mentioned in the issue https://github.com/codeborne/selenide/issues/631, this is especially useful if you want to filter an `ElementsCollection` by a condition on a child of each element instead of on the element itself.

