### PR TITLE
fix prompt() in HtmlUnit (new driver version 2.28.1) + new tests in AlertTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,9 +57,9 @@ dependencies {
   compile 'com.google.code.gson:gson:2.8.2'
   compile 'com.google.guava:guava:23.0'
   runtime 'commons-codec:commons-codec:1.10'
-  provided group: 'org.seleniumhq.selenium', name: 'htmlunit-driver', version: '2.27', transitive: false
-  provided group: 'net.sourceforge.htmlunit', name: 'htmlunit', version: '2.27'
-  testRuntime group: 'net.sourceforge.htmlunit', name: 'htmlunit', version: '2.27', transitive: false
+  provided group: 'org.seleniumhq.selenium', name: 'htmlunit-driver', version: '2.28.1', transitive: false
+  provided group: 'net.sourceforge.htmlunit', name: 'htmlunit', version: '2.28'
+  testRuntime group: 'net.sourceforge.htmlunit', name: 'htmlunit', version: '2.28', transitive: false
   compile('net.lightbody.bmp:browsermob-core:2.1.5')
   testRuntime group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25', transitive: false
 

--- a/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/src/main/java/com/codeborne/selenide/Selenide.java
@@ -512,7 +512,6 @@ public class Selenide {
 
   /**
    * Accept (Click "Yes" or "Ok") in the confirmation dialog (javascript 'alert' or 'confirm').
-   * Method does nothing in case of HtmlUnit browser (since HtmlUnit does not support alerts).
    *
    * @param expectedDialogText if not null, check that confirmation dialog displays this message (case-sensitive)
    * @throws DialogTextMismatch if confirmation message differs from expected message
@@ -548,7 +547,6 @@ public class Selenide {
 
   /**
    * Accept (Click "Yes" or "Ok") in the confirmation dialog (javascript 'prompt').
-   * Method does nothing in case of HtmlUnit browser (since HtmlUnit does not support alerts).
    *
    * @param expectedDialogText if not null, check that confirmation dialog displays this message (case-sensitive)
    * @param inputText if not null, sets value in prompt dialog input
@@ -579,7 +577,6 @@ public class Selenide {
 
   /**
    * Dismiss (click "No" or "Cancel") in the confirmation dialog (javascript 'alert' or 'confirm').
-   * Method does nothing in case of HtmlUnit browser (since HtmlUnit does not support alerts).
    *
    * @param expectedDialogText if not null, check that confirmation dialog displays this message (case-sensitive)
    * @throws DialogTextMismatch if confirmation message differs from expected message

--- a/src/main/java/com/codeborne/selenide/WebDriverRunner.java
+++ b/src/main/java/com/codeborne/selenide/WebDriverRunner.java
@@ -202,7 +202,7 @@ public class WebDriverRunner {
    * Does this browser support "alert" and "confirm" dialogs.
    */
   public static boolean supportsModalDialogs() {
-    return !isHeadless() && !isSafari();
+    return !isHeadless() && !isSafari() || isHtmlUnit();
   }
 
   /**

--- a/src/test/java/integration/AlertTest.java
+++ b/src/test/java/integration/AlertTest.java
@@ -29,6 +29,14 @@ public class AlertTest extends IntegrationTest {
   }
 
   @Test
+  public void canSubmitPromptDialogWithDefaultValue() {
+    $(byValue("Prompt button")).click();
+    prompt();
+    $("#message").shouldHave(text("Hello, default!"));
+    $("#container").shouldBe(empty);
+  }
+
+  @Test
   public void canSubmitPromptDialog() {
     $(byValue("Prompt button")).click();
     prompt("Please input your username", "Aegon Targaryen");

--- a/src/test/java/integration/AlertTest.java
+++ b/src/test/java/integration/AlertTest.java
@@ -10,10 +10,8 @@ import static com.codeborne.selenide.Condition.empty;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Selectors.byValue;
 import static com.codeborne.selenide.Selenide.*;
-import static com.codeborne.selenide.WebDriverRunner.isHtmlUnit;
 import static com.codeborne.selenide.WebDriverRunner.supportsModalDialogs;
 import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
 
 public class AlertTest extends IntegrationTest {
   @Before
@@ -32,8 +30,6 @@ public class AlertTest extends IntegrationTest {
 
   @Test
   public void canSubmitPromptDialog() {
-    assumeFalse(isHtmlUnit());
-
     $(byValue("Prompt button")).click();
     prompt("Please input your username", "Aegon Targaryen");
     $("#message").shouldHave(text("Hello, Aegon Targaryen!"));
@@ -63,7 +59,16 @@ public class AlertTest extends IntegrationTest {
     $("#message").shouldHave(text("Hello, Быстрый Гарри!"));
     $("#container").shouldBe(empty);
   }
-  
+
+  @Test
+  public void waitsUntilPromptDialogAppears() {
+    $(By.name("username")).val("Медленный Барри");
+    $(byValue("Slow prompt")).click();
+    prompt("Медленный Барри");
+    $("#message").shouldHave(text("Hello, Медленный Барри!"));
+    $("#container").shouldBe(empty);
+  }
+
   @AfterClass
   public static void tearDown() {
     close();

--- a/src/test/java/integration/customcommands/CustomCommandsTest.java
+++ b/src/test/java/integration/customcommands/CustomCommandsTest.java
@@ -7,9 +7,11 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.WebDriverRunner.isHtmlUnit;
 import static integration.customcommands.MyFramework.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 
 public class CustomCommandsTest extends IntegrationTest {
   @Before
@@ -21,9 +23,10 @@ public class CustomCommandsTest extends IntegrationTest {
   
   @Test
   public void userCanAddAnyCustomCommandsToSelenide() {
+    assumeFalse(isHtmlUnit());
     $_("#valid-image").tripleClick().tripleClick().tripleClick().click();
     $_("#invalid-image").tripleClick().quadrupleClick();
-    
+
     assertTrue("Can also use standard Selenium methods", $_("#valid-image img").isDisplayed());
     $_("#valid-image img").shouldBe(visible);
     

--- a/src/test/resources/page_with_alerts.html
+++ b/src/test/resources/page_with_alerts.html
@@ -8,7 +8,12 @@
         setTimeout(runAlert, 1000);
         return false;
       }
-      
+
+      function triggerPrompt() {
+        setTimeout(runPrompt, 1000);
+        return false;
+      }
+
       function runAlert() {
         var username = document.getElementById('username').value;
         alert("Are you sure, " + username + "?");
@@ -17,7 +22,7 @@
       }
 
       function runPrompt() {
-        var username = prompt("Please input your username");
+        var username = prompt("Please input your username", "default");
         document.getElementById('message').innerHTML = 'Hello, ' + username + '!';
         document.getElementById('container').innerHTML = '';
       }
@@ -56,6 +61,7 @@
           <a href="page_with_jquery.html" onclick="return runConfirm();">Confirm button</a><br/><br/>
 
           <input type="button" onclick="return triggerAlert();" value="Slow alert"><br/><br/>
+          <input type="button" onclick="return triggerPrompt();" value="Slow prompt"><br/><br/>
           <a href="page_with_jquery.html" onclick="return triggerConfirm();">Slow confirm</a><br/><br/>
         </fieldset>
       </form>


### PR DESCRIPTION
## Proposed changes
Fix HtmlUnit issues in PR #591.

Changed method supportsModalDialogs() from [WebDriverRunner.java](https://github.com/codeborne/selenide/blob/master/src/main/java/com/codeborne/selenide/WebDriverRunner.java), because now HtmlUnit 2.28 supports both alert() and prompt().

Update [page_with_alerts](https://github.com/codeborne/selenide/blob/master/src/test/resources/page_with_alerts.html) for new prompt() test.
New test **waitsUntilPromptDialogAppears()** in [AlertTest](https://github.com/codeborne/selenide/blob/master/src/test/java/integration/AlertTest.java) for prompt() with timeout.
Unignore test **canSubmitPromptDialog()** form HtmlUnit.

Ignore **userCanAddAnyCustomCommandsToSelenide()** in [CustomCommandsTest](https://github.com/codeborne/selenide/blob/master/src/test/java/integration/customcommands/CustomCommandsTest.java) for HtmlUnit.

UPD:
new test **canSubmitPromptDialogWithDefaultValue()** in [AlertTest](https://github.com/codeborne/selenide/blob/master/src/test/java/integration/AlertTest.java)

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [x] I have added tests that prove my fix is effective or that my feature works