### PR TITLE
Fixed #641 - Increased Elements Collection performance

### DIFF
--- a/src/main/java/com/codeborne/selenide/ElementsCollection.java
+++ b/src/main/java/com/codeborne/selenide/ElementsCollection.java
@@ -95,10 +95,8 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
       sleep(collectionsPollingInterval);
     }
     while (System.currentTimeMillis() - startTime < timeoutMs);
-
     condition.fail(collection, actualElements, lastError, timeoutMs);
   }
-
   void sleep(long ms) {
     Selenide.sleep(ms);
   }
@@ -242,7 +240,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
 
   @Override
   public SelenideElement get(int index) {
-    if(getActualElements().size() <= index){
+    if (getActualElements().size() <= index) {
       actualElements = collection.getActualElements();
     }
     return CollectionElement.wrap(collection, getActualElements(), index);

--- a/src/main/java/com/codeborne/selenide/ElementsCollection.java
+++ b/src/main/java/com/codeborne/selenide/ElementsCollection.java
@@ -95,10 +95,10 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
       sleep(collectionsPollingInterval);
     }
     while (System.currentTimeMillis() - startTime < timeoutMs);
-    
+
     condition.fail(collection, actualElements, lastError, timeoutMs);
   }
-  
+
   void sleep(long ms) {
     Selenide.sleep(ms);
   }
@@ -193,7 +193,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
   }
 
   /**
-   * @deprecated Use method com.codeborne.selenide.ElementsCollection#texts(java.util.Collection) 
+   * @deprecated Use method com.codeborne.selenide.ElementsCollection#texts(java.util.Collection)
    *              that returns List instead of array
    */
   @Deprecated
@@ -242,7 +242,10 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
 
   @Override
   public SelenideElement get(int index) {
-    return CollectionElement.wrap(collection, index);
+    if(getActualElements().size() <= index){
+      actualElements = collection.getActualElements();
+    }
+    return CollectionElement.wrap(collection, getActualElements(), index);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/impl/CollectionElement.java
+++ b/src/main/java/com/codeborne/selenide/impl/CollectionElement.java
@@ -3,30 +3,47 @@ package com.codeborne.selenide.impl;
 import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.ElementNotFound;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 
 import java.lang.reflect.Proxy;
+import java.util.List;
 
 import static com.codeborne.selenide.Condition.visible;
 
 public class CollectionElement extends WebElementSource {
-  public static SelenideElement wrap(WebElementsCollection collection, int index) {
+  public static SelenideElement wrap(WebElementsCollection collection, List<WebElement> actualElements, int index) {
     return (SelenideElement) Proxy.newProxyInstance(
         collection.getClass().getClassLoader(), new Class<?>[]{SelenideElement.class},
-        new SelenideElementProxy(new CollectionElement(collection, index)));
+        new SelenideElementProxy(new CollectionElement(collection, actualElements, index)));
   }
 
   private final WebElementsCollection collection;
+  private List<WebElement> actualElements;
   private final int index;
 
-  CollectionElement(WebElementsCollection collection, int index) {
+  CollectionElement(WebElementsCollection collection, List<WebElement> actualElements, int index) {
     this.collection = collection;
+    this.actualElements = actualElements;
     this.index = index;
   }
 
   @Override
   public WebElement getWebElement() {
-    return collection.getActualElements().get(index);
+    try {
+      WebElement el = actualElements.get(index);
+      el.isEnabled(); // check staleness
+
+      return el;
+    } catch(StaleElementReferenceException | IndexOutOfBoundsException e){
+      actualElements = collection.getActualElements();
+
+      if(actualElements.size() <= index){
+        throw e;
+      }else{
+        return actualElements.get(index);
+      }
+    }
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/impl/CollectionElement.java
+++ b/src/main/java/com/codeborne/selenide/impl/CollectionElement.java
@@ -35,14 +35,9 @@ public class CollectionElement extends WebElementSource {
       el.isEnabled(); // check staleness
 
       return el;
-    } catch(StaleElementReferenceException | IndexOutOfBoundsException e){
+    } catch (StaleElementReferenceException | IndexOutOfBoundsException e) {
       actualElements = collection.getActualElements();
-
-      if(actualElements.size() <= index){
-        throw e;
-      }else{
-        return actualElements.get(index);
-      }
+      return actualElements.get(index);
     }
   }
 

--- a/src/main/java/com/codeborne/selenide/impl/SelenideElementIterator.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideElementIterator.java
@@ -1,25 +1,29 @@
 package com.codeborne.selenide.impl;
 
 import com.codeborne.selenide.SelenideElement;
+import org.openqa.selenium.WebElement;
 
 import java.util.Iterator;
+import java.util.List;
 
 public class SelenideElementIterator implements Iterator<SelenideElement> {
   protected final WebElementsCollection collection;
+  protected List<WebElement> actualElements;
   protected int index;
 
   public SelenideElementIterator(WebElementsCollection collection) {
     this.collection = collection;
+    this.actualElements = collection.getActualElements();
   }
 
   @Override
   public boolean hasNext() {
-    return collection.getActualElements().size() > index;
+    return actualElements.size() > index || (actualElements = collection.getActualElements()).size() > index;
   }
 
   @Override
   public SelenideElement next() {
-    return CollectionElement.wrap(collection, index++);
+    return CollectionElement.wrap(collection, actualElements, index++);
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/impl/SelenideElementListIterator.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideElementListIterator.java
@@ -17,7 +17,7 @@ public class SelenideElementListIterator extends SelenideElementIterator impleme
 
   @Override
   public SelenideElement previous() {
-    return CollectionElement.wrap(collection, --index);
+    return CollectionElement.wrap(collection, actualElements, --index);
   }
 
   @Override

--- a/src/test/java/com/codeborne/selenide/impl/CollectionElementTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/CollectionElementTest.java
@@ -23,13 +23,14 @@ public class CollectionElementTest {
     when(mockedWebElement.isDisplayed()).thenReturn(true);
     when(mockedWebElement.getText()).thenReturn("selenide");
 
+    WebElementsCollection collection =
+            new WebElementsCollectionWrapper(singletonList(mockedWebElement));
     SelenideElement selenideElement = CollectionElement.wrap(
-        new WebElementsCollectionWrapper(singletonList(
-            mockedWebElement)), 0);
+        collection, collection.getActualElements(), 0);
     assertEquals("<a>selenide</a>", selenideElement.toString());
 
   }
-  
+
   @Test
   public void testGetWebElement() {
     WebElementsCollection mockedWebElementCollection = mock(WebElementsCollection.class);
@@ -37,7 +38,9 @@ public class CollectionElementTest {
     WebElement mockedWebElement2 = mock(WebElement.class);
     List<WebElement> listOfMockedElements = asList(mockedWebElement1, mockedWebElement2);
     when(mockedWebElementCollection.getActualElements()).thenReturn(listOfMockedElements);
-    CollectionElement collectionElement = new CollectionElement(mockedWebElementCollection, 1);
+    CollectionElement collectionElement = new CollectionElement(mockedWebElementCollection,
+                                                                mockedWebElementCollection.getActualElements(),
+                                                                1);
 
     assertEquals(mockedWebElement2, collectionElement.getWebElement());
   }
@@ -48,7 +51,9 @@ public class CollectionElementTest {
     int index = 1;
     WebElementsCollection mockedWebElementCollection = mock(WebElementsCollection.class);
     when(mockedWebElementCollection.description()).thenReturn(collectionDescription);
-    CollectionElement collectionElement = new CollectionElement(mockedWebElementCollection, index);
+    CollectionElement collectionElement = new CollectionElement(mockedWebElementCollection,
+                                                                mockedWebElementCollection.getActualElements(),
+                                                                1);
     assertEquals(String.format("%s[%s]", collectionDescription, index), collectionElement.getSearchCriteria());
   }
 
@@ -58,7 +63,9 @@ public class CollectionElementTest {
     String collectionDescription = "Collection description";
     when(mockedWebElementCollection.description()).thenReturn(collectionDescription);
     int index = 1;
-    CollectionElement collectionElement = new CollectionElement(mockedWebElementCollection, index);
+    CollectionElement collectionElement = new CollectionElement(mockedWebElementCollection,
+                                                                mockedWebElementCollection.getActualElements(),
+                                                                1);
     assertEquals(String.format("%s[%s]", collectionDescription, index), collectionElement.toString());
 
   }
@@ -69,7 +76,9 @@ public class CollectionElementTest {
     String collectionDescription = "Collection description";
     when(mockedWebElementCollection.description()).thenReturn(collectionDescription);
     int index = 1;
-    CollectionElement collectionElement = new CollectionElement(mockedWebElementCollection, index);
+    CollectionElement collectionElement = new CollectionElement(mockedWebElementCollection,
+                                                                mockedWebElementCollection.getActualElements(),
+                                                                1);
 
     Condition mockedCollection = mock(Condition.class);
     ElementNotFound elementNotFoundError = collectionElement.createElementNotFoundError(mockedCollection, new Error("Error message"));
@@ -88,7 +97,9 @@ public class CollectionElementTest {
     when(mockedWebElementCollection.description()).thenReturn(collectionDescription);
     when(mockedWebElementCollection.getActualElements()).thenReturn(asList(mock(WebElement.class)));
     int index = 1;
-    CollectionElement collectionElement = new CollectionElement(mockedWebElementCollection, index);
+    CollectionElement collectionElement = new CollectionElement(mockedWebElementCollection,
+                                                                mockedWebElementCollection.getActualElements(),
+                                                                1);
 
     Condition mockedCollection = mock(Condition.class);
     when(mockedCollection.toString()).thenReturn("Reason description");


### PR DESCRIPTION
## Proposed changes
Is a proposal for #641 fix. The idea is in storing of initial state of elements collection and reducing amount of `BySelectorCollection#getActualElements` calls.
Now collection is being re-evaluated only in cases of element staleness or trying to call `get(index)` where index is out of current bounds.

As a result same test on amount of `getActualElements()` calls from #641 now shows only 2 collection re-evaluating instead of 365 for a collection of 182 elements.

## Checklist
- [+] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [-] I didn't provide any tests for performance but made sure that tests on staleness still work