### PR TITLE
Fix #660 - Remote driver factory should take into account headless option

### DIFF
--- a/src/main/java/com/codeborne/selenide/webdriver/RemoteDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/RemoteDriverFactory.java
@@ -1,7 +1,10 @@
 package com.codeborne.selenide.webdriver;
 
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.remote.BrowserType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.LocalFileDetector;
@@ -11,6 +14,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 import static com.codeborne.selenide.Configuration.browser;
+import static com.codeborne.selenide.Configuration.headless;
 import static com.codeborne.selenide.Configuration.remote;
 import static com.codeborne.selenide.WebDriverRunner.*;
 
@@ -28,14 +32,35 @@ class RemoteDriverFactory extends AbstractDriverFactory {
 
   private WebDriver createRemoteDriver(final String remote, final String browser, final Proxy proxy) {
     try {
-      DesiredCapabilities capabilities = createCommonCapabilities(proxy);
-      capabilities.setBrowserName(getBrowserNameForGrid());
+      DesiredCapabilities capabilities = getDriverCapabilities(proxy);
       RemoteWebDriver webDriver = new RemoteWebDriver(new URL(remote), capabilities);
       webDriver.setFileDetector(new LocalFileDetector());
       return webDriver;
     } catch (MalformedURLException e) {
       throw new IllegalArgumentException("Invalid 'remote' parameter: " + remote, e);
     }
+  }
+
+  DesiredCapabilities getDriverCapabilities(Proxy proxy) {
+    DesiredCapabilities capabilities = createCommonCapabilities(proxy);
+    capabilities.setBrowserName(getBrowserNameForGrid());
+    if (headless) {
+      capabilities.merge(getHeadlessCapabilities());
+    }
+    return capabilities;
+  }
+
+  Capabilities getHeadlessCapabilities() {
+    if (isChrome()) {
+      ChromeOptions options = new ChromeOptions();
+      options.setHeadless(headless);
+      return options;
+    } else if (isFirefox()) {
+      FirefoxOptions options = new FirefoxOptions();
+      options.setHeadless(headless);
+      return options;
+    }
+    return new DesiredCapabilities();
   }
 
   String getBrowserNameForGrid() {

--- a/src/test/java/com/codeborne/selenide/webdriver/ChomeDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/ChomeDriverFactoryTest.java
@@ -1,12 +1,12 @@
 package com.codeborne.selenide.webdriver;
 
+import static com.codeborne.selenide.webdriver.SeleniumCapabilitiesHelper.getBrowserLaunchArgs;
 import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import org.junit.After;
 import org.junit.Test;
 import org.openqa.selenium.Proxy;
@@ -25,11 +25,8 @@ public class ChomeDriverFactoryTest {
   @Test
   public void transferChromeOptionArgumentsFromSystemPropsToDriver() throws IOException {
     System.setProperty("chromeoptions.args", "abdd,--abcd,xcvcd=123");
-
     ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(proxy);
-    Map<String, Object> chromeArgs = (Map<String, Object>) chromeOptions.asMap()
-        .get("goog:chromeOptions");
-    List<String> optionArguments = (List<String>) chromeArgs.get("args");
+    List<String> optionArguments = getBrowserLaunchArgs(ChromeOptions.CAPABILITY, chromeOptions);
 
     assertThat(optionArguments, hasItems("abdd"));
     assertThat(optionArguments, hasItems("--abcd"));

--- a/src/test/java/com/codeborne/selenide/webdriver/RemoteDriverFactoryHeadlessOptionsTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/RemoteDriverFactoryHeadlessOptionsTest.java
@@ -2,12 +2,13 @@ package com.codeborne.selenide.webdriver;
 
 import com.codeborne.selenide.Configuration;
 import java.util.List;
+
+import org.junit.After;
 import org.junit.Test;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxOptions;
-import org.testng.annotations.AfterTest;
 
 import static com.codeborne.selenide.webdriver.SeleniumCapabilitiesHelper.getBrowserLaunchArgs;
 import static org.hamcrest.Matchers.not;
@@ -20,14 +21,14 @@ public class RemoteDriverFactoryHeadlessOptionsTest {
   private RemoteDriverFactory factory = new RemoteDriverFactory();
   private Proxy proxy = mock(Proxy.class);
 
-  @AfterTest
+  @After
   public void tearDown() {
     Configuration.browser = null;
     Configuration.headless = false;
   }
 
   @Test
-  public void shouldNotAddChromeHeadlessOptions() throws Exception {
+  public void shouldNotAddChromeHeadlessOptions() {
     Configuration.headless = true;
     Configuration.browser = "chrome";
 
@@ -39,7 +40,7 @@ public class RemoteDriverFactoryHeadlessOptionsTest {
   }
 
   @Test
-  public void shouldNotAddFirefoxHeadlessOptions() throws Exception {
+  public void shouldNotAddFirefoxHeadlessOptions() {
     Configuration.headless = true;
     Configuration.browser = "firefox";
 
@@ -50,7 +51,7 @@ public class RemoteDriverFactoryHeadlessOptionsTest {
   }
 
   @Test
-  public void shouldAddChromeHeadlessOptions() throws Exception {
+  public void shouldAddChromeHeadlessOptions() {
     Configuration.browser = "chrome";
 
     Capabilities headlessCapabilities = factory.getDriverCapabilities(proxy);
@@ -61,7 +62,7 @@ public class RemoteDriverFactoryHeadlessOptionsTest {
   }
 
   @Test
-  public void shouldAddFirefoxHeadlessOptions() throws Exception {
+  public void shouldAddFirefoxHeadlessOptions() {
     Configuration.browser = "firefox";
 
     Capabilities headlessCapabilities = factory.getDriverCapabilities(proxy);

--- a/src/test/java/com/codeborne/selenide/webdriver/RemoteDriverFactoryHeadlessOptionsTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/RemoteDriverFactoryHeadlessOptionsTest.java
@@ -1,0 +1,73 @@
+package com.codeborne.selenide.webdriver;
+
+import com.codeborne.selenide.Configuration;
+import java.util.List;
+import org.junit.Test;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.Proxy;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.firefox.FirefoxOptions;
+import org.testng.annotations.AfterTest;
+
+import static com.codeborne.selenide.webdriver.SeleniumCapabilitiesHelper.getBrowserLaunchArgs;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.core.IsCollectionContaining.hasItems;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class RemoteDriverFactoryHeadlessOptionsTest {
+
+  private RemoteDriverFactory factory = new RemoteDriverFactory();
+  private Proxy proxy = mock(Proxy.class);
+
+  @AfterTest
+  public void tearDown() {
+    Configuration.browser = null;
+    Configuration.headless = false;
+  }
+
+  @Test
+  public void shouldNotAddChromeHeadlessOptions() throws Exception {
+    Configuration.headless = true;
+    Configuration.browser = "chrome";
+
+    Capabilities headlessCapabilities = factory.getDriverCapabilities(proxy);
+    List<String> launchArguments = getBrowserLaunchArgs(ChromeOptions.CAPABILITY, headlessCapabilities);
+
+    assertThat(launchArguments, hasItems("--headless"));
+    assertThat(launchArguments, hasItems("--disable-gpu"));
+  }
+
+  @Test
+  public void shouldNotAddFirefoxHeadlessOptions() throws Exception {
+    Configuration.headless = true;
+    Configuration.browser = "firefox";
+
+    Capabilities headlessCapabilities = factory.getDriverCapabilities(proxy);
+    List<String> launchArguments = getBrowserLaunchArgs(FirefoxOptions.FIREFOX_OPTIONS, headlessCapabilities);
+
+    assertThat(launchArguments, hasItems("-headless"));
+  }
+
+  @Test
+  public void shouldAddChromeHeadlessOptions() throws Exception {
+    Configuration.browser = "chrome";
+
+    Capabilities headlessCapabilities = factory.getDriverCapabilities(proxy);
+    List<String> launchArguments = getBrowserLaunchArgs(ChromeOptions.CAPABILITY, headlessCapabilities);
+
+    assertThat(launchArguments, not(hasItems("--headless")));
+    assertThat(launchArguments, not(hasItems("--disable-gpu")));
+  }
+
+  @Test
+  public void shouldAddFirefoxHeadlessOptions() throws Exception {
+    Configuration.browser = "firefox";
+
+    Capabilities headlessCapabilities = factory.getDriverCapabilities(proxy);
+    List<String> launchArguments = getBrowserLaunchArgs(FirefoxOptions.FIREFOX_OPTIONS, headlessCapabilities);
+
+    assertThat(launchArguments, not(hasItems("-headless")));
+  }
+
+}

--- a/src/test/java/com/codeborne/selenide/webdriver/SeleniumCapabilitiesHelper.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/SeleniumCapabilitiesHelper.java
@@ -1,0 +1,20 @@
+package com.codeborne.selenide.webdriver;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.openqa.selenium.Capabilities;
+
+class SeleniumCapabilitiesHelper {
+
+  @SuppressWarnings("unchecked")
+  static List<String> getBrowserLaunchArgs(String capability, Capabilities capabilities) {
+    // it depends on internal Selenium capabilities structure
+    // but there are no ways to do the same by public interfaces
+    Map<String, Object> arguments = (Map<String, Object>) capabilities.asMap().get(capability);
+    if (arguments == null) {
+      return Collections.emptyList();
+    }
+    return (List<String>) arguments.get("args");
+  }
+}


### PR DESCRIPTION
## Proposed changes
Fix https://github.com/codeborne/selenide/issues/660
Remote driver factory should take into account headless option.

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)