### PR TITLE
#672 fix lazy evaluation of page objects fields...

### DIFF
--- a/src/main/java/com/codeborne/selenide/ElementsCollection.java
+++ b/src/main/java/com/codeborne/selenide/ElementsCollection.java
@@ -18,8 +18,6 @@ import static java.util.stream.Collectors.toList;
 
 public class ElementsCollection extends AbstractList<SelenideElement> {
   private final WebElementsCollection collection;
-  private List<WebElement> actualElements;
-  private Exception lastError;
 
   public ElementsCollection(WebElementsCollection collection) {
     this.collection = collection;
@@ -77,7 +75,8 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
   }
 
   protected void waitUntil(CollectionCondition condition, long timeoutMs) {
-    lastError = null;
+    Exception lastError = null;
+    List<WebElement> actualElements = null;
     final long startTime = System.currentTimeMillis();
     do {
       try {
@@ -85,7 +84,8 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
         if (condition.apply(actualElements)) {
           return;
         }
-      } catch (WebDriverException elementNotFound) {
+      }
+      catch (WebDriverException elementNotFound) {
         lastError = elementNotFound;
 
         if (Cleanup.of.isInvalidSelectorError(elementNotFound)) {
@@ -158,11 +158,8 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
     return find(condition);
   }
 
-  private List<WebElement> getActualElements() {
-    if (actualElements == null) {
-      actualElements = collection.getActualElements();
-    }
-    return actualElements;
+  private List<WebElement> getElements() {
+    return collection.getElements();
   }
 
   /**
@@ -170,7 +167,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    * @return array of texts
    */
   public List<String> texts() {
-    return texts(getActualElements());
+    return texts(getElements());
   }
 
   /**
@@ -178,7 +175,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    */
   @Deprecated
   public String[] getTexts() {
-    return getTexts(getActualElements());
+    return getTexts(getElements());
   }
 
   /**
@@ -240,10 +237,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
 
   @Override
   public SelenideElement get(int index) {
-    if (getActualElements().size() <= index) {
-      actualElements = collection.getActualElements();
-    }
-    return CollectionElement.wrap(collection, getActualElements(), index);
+    return CollectionElement.wrap(collection, index);
   }
 
   /**
@@ -268,7 +262,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    * @return
    */
   public ElementsCollection first(int elements) {
-    List<WebElement> sublist = getActualElements().subList(0, Math.min(elements, size()));
+    List<WebElement> sublist = getElements().subList(0, Math.min(elements, size()));
     return new ElementsCollection(new WebElementsCollectionWrapper(sublist));
   }
 
@@ -278,13 +272,13 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    * @return
    */
   public ElementsCollection last(int elements) {
-    List<WebElement> sublist = getActualElements().subList(Math.max(size() - elements, 0), size());
+    List<WebElement> sublist = getElements().subList(Math.max(size() - elements, 0), size());
     return new ElementsCollection(new WebElementsCollectionWrapper(sublist));
   }
 
   @Override
   public int size() {
-    return getActualElements().size();
+    return getElements().size();
   }
 
   @Override
@@ -300,7 +294,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
   @Override
   public String toString() {
     try {
-      return elementsToString(getActualElements());
+      return elementsToString(getElements());
     } catch (Exception e) {
       return String.format("[%s]", Cleanup.of.webdriverExceptionMessage(e));
     }

--- a/src/main/java/com/codeborne/selenide/commands/GetSelectedOptions.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetSelectedOptions.java
@@ -15,6 +15,11 @@ public class GetSelectedOptions implements Command<ElementsCollection> {
   public ElementsCollection execute(SelenideElement proxy, final WebElementSource selectElement, Object[] args) {
     return new ElementsCollection(new WebElementsCollection() {
       @Override
+      public List<WebElement> getElements() {
+        return getActualElements();
+      }
+
+      @Override
       public List<WebElement> getActualElements() {
         return new Select(selectElement.getWebElement()).getAllSelectedOptions();
       }

--- a/src/main/java/com/codeborne/selenide/impl/BySelectorCollection.java
+++ b/src/main/java/com/codeborne/selenide/impl/BySelectorCollection.java
@@ -13,6 +13,7 @@ public class BySelectorCollection implements WebElementsCollection {
 
   private final SearchContext parent;
   private final By selector;
+  private List<WebElement> actualElements;
 
   public BySelectorCollection(By selector) {
     this(null, selector);
@@ -24,9 +25,18 @@ public class BySelectorCollection implements WebElementsCollection {
   }
 
   @Override
+  public List<WebElement> getElements() {
+    if (actualElements == null) {
+      return getActualElements();
+    }
+    return actualElements;
+  }
+
+  @Override
   public List<WebElement> getActualElements() {
     SearchContext searchContext = parent == null ? getWebDriver() : parent;
-    return WebElementSelector.instance.findElements(searchContext, selector);
+    actualElements = WebElementSelector.instance.findElements(searchContext, selector);
+    return actualElements;
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/impl/CollectionElement.java
+++ b/src/main/java/com/codeborne/selenide/impl/CollectionElement.java
@@ -7,37 +7,33 @@ import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 
 import java.lang.reflect.Proxy;
-import java.util.List;
 
 import static com.codeborne.selenide.Condition.visible;
 
 public class CollectionElement extends WebElementSource {
-  public static SelenideElement wrap(WebElementsCollection collection, List<WebElement> actualElements, int index) {
+  public static SelenideElement wrap(WebElementsCollection collection, int index) {
     return (SelenideElement) Proxy.newProxyInstance(
         collection.getClass().getClassLoader(), new Class<?>[]{SelenideElement.class},
-        new SelenideElementProxy(new CollectionElement(collection, actualElements, index)));
+        new SelenideElementProxy(new CollectionElement(collection, index)));
   }
 
   private final WebElementsCollection collection;
-  private List<WebElement> actualElements;
   private final int index;
 
-  CollectionElement(WebElementsCollection collection, List<WebElement> actualElements, int index) {
+  CollectionElement(WebElementsCollection collection, int index) {
     this.collection = collection;
-    this.actualElements = actualElements;
     this.index = index;
   }
 
   @Override
   public WebElement getWebElement() {
     try {
-      WebElement el = actualElements.get(index);
+      WebElement el = collection.getElements().get(index);
       el.isEnabled(); // check staleness
 
       return el;
     } catch (StaleElementReferenceException | IndexOutOfBoundsException e) {
-      actualElements = collection.getActualElements();
-      return actualElements.get(index);
+      return collection.getActualElements().get(index);
     }
   }
 

--- a/src/main/java/com/codeborne/selenide/impl/FilteringCollection.java
+++ b/src/main/java/com/codeborne/selenide/impl/FilteringCollection.java
@@ -1,15 +1,17 @@
 package com.codeborne.selenide.impl;
 
 import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.Lists;
 import org.openqa.selenium.WebElement;
 
+import java.util.ArrayList;
 import java.util.List;
+
+import static com.google.common.collect.Collections2.filter;
 
 public class FilteringCollection implements WebElementsCollection {
   private final WebElementsCollection originalCollection;
   private final Predicate<WebElement> filter;
+  private List<WebElement> actualElements;
 
   public FilteringCollection(WebElementsCollection originalCollection, Predicate<WebElement> filter) {
     this.originalCollection = originalCollection;
@@ -17,8 +19,17 @@ public class FilteringCollection implements WebElementsCollection {
   }
 
   @Override
+  public List<WebElement> getElements() {
+    if (actualElements == null) {
+      return getActualElements();
+    }
+    return actualElements;
+  }
+
+  @Override
   public List<WebElement> getActualElements() {
-    return Lists.newArrayList(Collections2.filter(originalCollection.getActualElements(), filter));
+    actualElements = new ArrayList<>(filter(originalCollection.getActualElements(), filter));
+    return actualElements;
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/impl/SelenideElementIterator.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideElementIterator.java
@@ -1,29 +1,25 @@
 package com.codeborne.selenide.impl;
 
 import com.codeborne.selenide.SelenideElement;
-import org.openqa.selenium.WebElement;
 
 import java.util.Iterator;
-import java.util.List;
 
 public class SelenideElementIterator implements Iterator<SelenideElement> {
   protected final WebElementsCollection collection;
-  protected List<WebElement> actualElements;
   protected int index;
 
   public SelenideElementIterator(WebElementsCollection collection) {
     this.collection = collection;
-    this.actualElements = collection.getActualElements();
   }
 
   @Override
   public boolean hasNext() {
-    return actualElements.size() > index || (actualElements = collection.getActualElements()).size() > index;
+    return collection.getElements().size() > index || (collection.getActualElements()).size() > index;
   }
 
   @Override
   public SelenideElement next() {
-    return CollectionElement.wrap(collection, actualElements, index++);
+    return CollectionElement.wrap(collection, index++);
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/impl/SelenideElementListIterator.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideElementListIterator.java
@@ -17,7 +17,7 @@ public class SelenideElementListIterator extends SelenideElementIterator impleme
 
   @Override
   public SelenideElement previous() {
-    return CollectionElement.wrap(collection, actualElements, --index);
+    return CollectionElement.wrap(collection, --index);
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/impl/WebElementsCollection.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebElementsCollection.java
@@ -5,6 +5,19 @@ import org.openqa.selenium.WebElement;
 import java.util.List;
 
 public interface WebElementsCollection {
+  /**
+   * gets currently loaded collection (probably cached).
+   * If collection is not loaded yet, calls #getActualElements().
+   * If you need to load the freshest data (not cached), call #getActualElements().
+   *
+   * @see #getActualElements()
+   */
+  List<WebElement> getElements();
+
+  /**
+   * fetches the current collection state from the webdriver
+   */
   List<WebElement> getActualElements();
+
   String description();
 }

--- a/src/main/java/com/codeborne/selenide/impl/WebElementsCollectionWrapper.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebElementsCollectionWrapper.java
@@ -10,8 +10,12 @@ public class WebElementsCollectionWrapper implements WebElementsCollection {
   private final List<WebElement> elements;
 
   public WebElementsCollectionWrapper(Collection<? extends WebElement> elements) {
-    this.elements = new ArrayList<>(elements.size());
-    this.elements.addAll(elements);
+    this.elements = new ArrayList<>(elements);
+  }
+
+  @Override
+  public List<WebElement> getElements() {
+    return elements;
   }
 
   @Override

--- a/src/test/java/com/codeborne/selenide/ElementsCollectionTest.java
+++ b/src/test/java/com/codeborne/selenide/ElementsCollectionTest.java
@@ -53,29 +53,17 @@ public class ElementsCollectionTest {
   }
 
   @Test
-  public void toStringPrintsOutLastFetchedElements() {
-    WebElementsCollection source = mock(WebElementsCollection.class);
-    ElementsCollection collection = new ElementsCollection(source);
-    when(source.getActualElements()).thenReturn(asList(element1, element2));
-    collection.shouldHave(size(2)); // fetches elements
-    
-    when(source.getActualElements()).thenThrow(new WebDriverException("Failed to fetch elements"));
-    
-    assertEquals("[\n\t<h1></h1>,\n\t<h2></h2>\n]", collection.toString());
-  }
-
-  @Test
   public void toStringFetchedCollectionFromWebdriverIfNotFetchedYet() {
     WebElementsCollection source = mock(WebElementsCollection.class);
     ElementsCollection collection = new ElementsCollection(source);
-    when(source.getActualElements()).thenReturn(asList(element1, element2));
+    when(source.getElements()).thenReturn(asList(element1, element2));
     assertEquals("[\n\t<h1></h1>,\n\t<h2></h2>\n]", collection.toString());
   }
 
   @Test
   public void toStringPrintsErrorIfFailedToFetchElements() {
     WebElementsCollection source = mock(WebElementsCollection.class);
-    when(source.getActualElements()).thenThrow(new WebDriverException("Failed to fetch elements"));
+    when(source.getElements()).thenThrow(new WebDriverException("Failed to fetch elements"));
     assertEquals("[WebDriverException: Failed to fetch elements]", new ElementsCollection(source).toString());
   }
 

--- a/src/test/java/com/codeborne/selenide/impl/CollectionElementTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/CollectionElementTest.java
@@ -23,10 +23,8 @@ public class CollectionElementTest {
     when(mockedWebElement.isDisplayed()).thenReturn(true);
     when(mockedWebElement.getText()).thenReturn("selenide");
 
-    WebElementsCollection collection =
-            new WebElementsCollectionWrapper(singletonList(mockedWebElement));
-    SelenideElement selenideElement = CollectionElement.wrap(
-        collection, collection.getActualElements(), 0);
+    WebElementsCollection collection = new WebElementsCollectionWrapper(singletonList(mockedWebElement));
+    SelenideElement selenideElement = CollectionElement.wrap(collection, 0);
     assertEquals("<a>selenide</a>", selenideElement.toString());
 
   }
@@ -38,9 +36,7 @@ public class CollectionElementTest {
     WebElement mockedWebElement2 = mock(WebElement.class);
     List<WebElement> listOfMockedElements = asList(mockedWebElement1, mockedWebElement2);
     when(mockedWebElementCollection.getActualElements()).thenReturn(listOfMockedElements);
-    CollectionElement collectionElement = new CollectionElement(mockedWebElementCollection,
-                                                                mockedWebElementCollection.getActualElements(),
-                                                                1);
+    CollectionElement collectionElement = new CollectionElement(mockedWebElementCollection, 1);
 
     assertEquals(mockedWebElement2, collectionElement.getWebElement());
   }
@@ -51,9 +47,7 @@ public class CollectionElementTest {
     int index = 1;
     WebElementsCollection mockedWebElementCollection = mock(WebElementsCollection.class);
     when(mockedWebElementCollection.description()).thenReturn(collectionDescription);
-    CollectionElement collectionElement = new CollectionElement(mockedWebElementCollection,
-                                                                mockedWebElementCollection.getActualElements(),
-                                                                1);
+    CollectionElement collectionElement = new CollectionElement(mockedWebElementCollection, 1);
     assertEquals(String.format("%s[%s]", collectionDescription, index), collectionElement.getSearchCriteria());
   }
 
@@ -63,9 +57,7 @@ public class CollectionElementTest {
     String collectionDescription = "Collection description";
     when(mockedWebElementCollection.description()).thenReturn(collectionDescription);
     int index = 1;
-    CollectionElement collectionElement = new CollectionElement(mockedWebElementCollection,
-                                                                mockedWebElementCollection.getActualElements(),
-                                                                1);
+    CollectionElement collectionElement = new CollectionElement(mockedWebElementCollection, 1);
     assertEquals(String.format("%s[%s]", collectionDescription, index), collectionElement.toString());
 
   }
@@ -75,10 +67,7 @@ public class CollectionElementTest {
     WebElementsCollection mockedWebElementCollection = mock(WebElementsCollection.class);
     String collectionDescription = "Collection description";
     when(mockedWebElementCollection.description()).thenReturn(collectionDescription);
-    int index = 1;
-    CollectionElement collectionElement = new CollectionElement(mockedWebElementCollection,
-                                                                mockedWebElementCollection.getActualElements(),
-                                                                1);
+    CollectionElement collectionElement = new CollectionElement(mockedWebElementCollection, 1);
 
     Condition mockedCollection = mock(Condition.class);
     ElementNotFound elementNotFoundError = collectionElement.createElementNotFoundError(mockedCollection, new Error("Error message"));
@@ -95,11 +84,8 @@ public class CollectionElementTest {
     WebElementsCollection mockedWebElementCollection = mock(WebElementsCollection.class);
     String collectionDescription = "Collection description";
     when(mockedWebElementCollection.description()).thenReturn(collectionDescription);
-    when(mockedWebElementCollection.getActualElements()).thenReturn(asList(mock(WebElement.class)));
-    int index = 1;
-    CollectionElement collectionElement = new CollectionElement(mockedWebElementCollection,
-                                                                mockedWebElementCollection.getActualElements(),
-                                                                1);
+    when(mockedWebElementCollection.getActualElements()).thenReturn(singletonList(mock(WebElement.class)));
+    CollectionElement collectionElement = new CollectionElement(mockedWebElementCollection, 1);
 
     Condition mockedCollection = mock(Condition.class);
     when(mockedCollection.toString()).thenReturn("Reason description");

--- a/src/test/java/integration/LazyEvaluationTest.java
+++ b/src/test/java/integration/LazyEvaluationTest.java
@@ -1,0 +1,44 @@
+package integration;
+
+import com.codeborne.selenide.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.codeborne.selenide.CollectionCondition.*;
+import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.$$;
+
+
+public class LazyEvaluationTest extends IntegrationTest {
+
+  static SelenideElement h1 = $("h1");
+  static SelenideElement button = $("#double-clickable-button");
+
+  static SelenideElement input1 = $$("input").first();
+  static SelenideElement input2 = $$("input").last();
+  static SelenideElement input3 = $$("input").get(1);
+
+  static ElementsCollection inputs = $$("input").filterBy(visible);
+
+  @Before
+  public void openTestPageWithImages() {
+    openFile("page_with_jquery.html");
+  }
+
+  @Test
+  public void singleElementLazyFound() {
+    h1.shouldBe(visible);
+    button.click();
+  }
+
+  @Test
+  public void collectionRelatedLazyOperations() {
+    input1.shouldBe(visible);
+    input2.shouldBe(visible);
+    input3.shouldBe(visible);
+    inputs.shouldHave(sizeGreaterThanOrEqual(1));
+  }
+
+
+}

--- a/src/test/java/integration/PageObjectWithManuallyInitializedFieldsTest.java
+++ b/src/test/java/integration/PageObjectWithManuallyInitializedFieldsTest.java
@@ -26,11 +26,12 @@ public class PageObjectWithManuallyInitializedFieldsTest extends IntegrationTest
     page.h1.shouldHave(Condition.text("Page with selects"));
     assertEquals(3, page.h2s.size());
     page.h2s.get(0).shouldBe(visible).shouldHave(text("Dropdown list"));
+    page.h2First.shouldBe(visible).shouldHave(text("Dropdown list"));
   }
-
 
   private static class MyPage {
     SelenideElement h1 = $("h1");
     List<SelenideElement> h2s = $$("h2");
+    SelenideElement h2First = $$("h2").get(0);
   }
 }


### PR DESCRIPTION
… declared as `$$().get(index)`

to achieve that, I added method `WebElementsCollection.getElements()`
and made some of `WebElementsCollection` implementations cache the result of `getActualElements()`.

it allowed me to remove field `actualElements` from `ElementsCollection`, `CollectionElement`, `SelenideElementIterator`.
Thus method `ElementsCollection.get(index)` doesn't need to load the collection immediately, but just returns a "proxy" - `CollectionElement`.

## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)