### PR TITLE
Bug fix for occasional NPE's in SelenideReport 

### DIFF
--- a/src/main/java/com/codeborne/selenide/logevents/SimpleReport.java
+++ b/src/main/java/com/codeborne/selenide/logevents/SimpleReport.java
@@ -21,10 +21,10 @@ public class SimpleReport {
   public void finish(String title) {
     EventsCollector logEventListener = SelenideLogger.removeListener("simpleReport");
 
-      if (logEventListener == null) {
-          log.warning("Can not publish report because Selenide logger has not started.");
-          return;
-      }
+    if (logEventListener == null) {
+      log.warning("Can not publish report because Selenide logger has not started.");
+      return;
+    }
 
     OptionalInt maxLineLength = logEventListener.events()
             .stream()

--- a/src/main/java/com/codeborne/selenide/logevents/SimpleReport.java
+++ b/src/main/java/com/codeborne/selenide/logevents/SimpleReport.java
@@ -21,6 +21,11 @@ public class SimpleReport {
   public void finish(String title) {
     EventsCollector logEventListener = SelenideLogger.removeListener("simpleReport");
 
+      if (logEventListener == null) {
+          log.warning("Can not publish report because Selenide logger has not started.");
+          return;
+      }
+
     OptionalInt maxLineLength = logEventListener.events()
             .stream()
             .map(LogEvent::getElement)

--- a/src/test/java/com/codeborne/selenide/logevents/SimpleReportTest.java
+++ b/src/test/java/com/codeborne/selenide/logevents/SimpleReportTest.java
@@ -1,0 +1,12 @@
+package com.codeborne.selenide.logevents;
+
+import org.junit.Test;
+
+public class SimpleReportTest {
+
+    @Test
+    public void reportShouldNotThrowNpe() {
+        new SimpleReport().finish("test");
+    }
+
+}

--- a/src/test/java/com/codeborne/selenide/logevents/SimpleReportTest.java
+++ b/src/test/java/com/codeborne/selenide/logevents/SimpleReportTest.java
@@ -4,9 +4,9 @@ import org.junit.Test;
 
 public class SimpleReportTest {
 
-    @Test
-    public void reportShouldNotThrowNpe() {
-        new SimpleReport().finish("test");
-    }
+  @Test
+  public void reportShouldNotThrowNpe() {
+    new SimpleReport().finish("test");
+  }
 
 }


### PR DESCRIPTION
## Proposed changes
Bug fix for occasional NPE's in SelenideReport when used with TestNg listeners.
On certain occasions - when SimpleReport.start() method was not called for any reason, SelenideReport.finish() was causing NPE.

## Checklist
- [+] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [+ ] I have added tests that prove my fix is effective or that my feature works
- [n/a] I have added necessary documentation (if appropriate)