### PR TITLE
Enable sandbox for chrome.

### DIFF
--- a/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
@@ -35,7 +35,6 @@ class ChromeDriverFactory extends AbstractDriverFactory {
     if (!browserBinary.isEmpty()) {
       options.setBinary(browserBinary);
     }
-    options.addArguments("--no-sandbox");  // This make Chromium reachable (?)
     if (chromeSwitches != null) {
       options.addArguments(chromeSwitches);
     }


### PR DESCRIPTION
## Proposed changes
This PR fix issue about not closing chrome instance on windows.
References:
* [AT info](http://automated-testing.info/t/v-selenide-ne-zakryvayutsya-proczessy-chrome-posle-close/19608)
* [Chromuim chromedriver](https://bugs.chromium.org/p/chromedriver/issues/detail?id=2311)

If you want to restore such behavior manually pass `--no-sandbox` chrome option.

Feature [build](https://jitpack.io/#rosolko/selenide/sandbox-SNAPSHOT)

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)