### PR TITLE
introduce setValueChangeEvent option

### DIFF
--- a/src/main/java/com/codeborne/selenide/Configuration.java
+++ b/src/main/java/com/codeborne/selenide/Configuration.java
@@ -302,6 +302,18 @@ public class Configuration {
   public static boolean versatileSetValue = Boolean.parseBoolean(System.getProperty("selenide.versatileSetValue", "false"));
 
   /**
+   * If set to true, 'setValue' and 'val' methods of SelenideElement trigger changeEvent after main manipulations.
+   *
+   * Firing change event, is not natural and could lead to unpredictable results. It is done by browser according
+   * to web driver actions. Recommended behaviour is to disable this option.
+   * Make it true by default, for backward compatibility.
+   *
+   * Can be configured either programmatically or by system property "-Dselenide.setValueChangeEvent=true".
+   * Default value: true
+   */
+  public static boolean setValueChangeEvent = Boolean.parseBoolean(System.getProperty("selenide.setValueChangeEvent", "true"));
+
+  /**
    * Choose how Selenide should retrieve web elements: using default CSS or Sizzle (CSS3)
    */
   public static SelectorMode selectorMode = CSS;

--- a/src/main/java/com/codeborne/selenide/commands/Append.java
+++ b/src/main/java/com/codeborne/selenide/commands/Append.java
@@ -5,6 +5,7 @@ import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
 import org.openqa.selenium.WebElement;
 
+import static com.codeborne.selenide.Configuration.setValueChangeEvent;
 import static com.codeborne.selenide.impl.Events.events;
 
 public class Append implements Command<WebElement> {
@@ -12,7 +13,9 @@ public class Append implements Command<WebElement> {
   public WebElement execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
     WebElement input = locator.getWebElement();
     input.sendKeys((String) args[0]);
-    events.fireChangeEvent(input);
+    if (setValueChangeEvent) {
+      events.fireChangeEvent(input);
+    }
     return proxy;
   }
 }

--- a/src/main/java/com/codeborne/selenide/commands/SetValue.java
+++ b/src/main/java/com/codeborne/selenide/commands/SetValue.java
@@ -8,6 +8,7 @@ import com.codeborne.selenide.impl.WebElementSource;
 import org.openqa.selenium.WebElement;
 
 import static com.codeborne.selenide.Configuration.fastSetValue;
+import static com.codeborne.selenide.Configuration.setValueChangeEvent;
 import static com.codeborne.selenide.Selenide.executeJavaScript;
 import static com.codeborne.selenide.impl.Events.events;
 
@@ -55,7 +56,9 @@ public class SetValue implements Command<WebElement> {
     } else {
       element.clear();
       element.sendKeys(text);
-      events.fireChangeEvent(element);
+      if (setValueChangeEvent) {
+        events.fireChangeEvent(element);
+      }
     }
   }
 


### PR DESCRIPTION
## Proposed changes
New option "setValueChangeEvent". It's needed for disabling fire change event. 
## Checklist
[ +] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
[ - ] I have added tests that prove my fix is effective or that my feature works
[ + ] I have added necessary documentation (if appropriate)