### PR TITLE
Adding new Condition - moving

### DIFF
--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -4,14 +4,12 @@ import com.codeborne.selenide.conditions.Text;
 import com.codeborne.selenide.impl.Describe;
 import com.codeborne.selenide.impl.Html;
 import com.google.common.base.Predicate;
-import com.google.common.util.concurrent.Uninterruptibles;
 import org.openqa.selenium.Point;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.internal.Locatable;
 
 import static com.codeborne.selenide.Selenide.getFocusedElement;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * Conditions to match web elements: checks for visibility, text etc.
@@ -106,25 +104,34 @@ public abstract class Condition implements Predicate<WebElement> {
   public static final Condition disappear = hidden;
 
   /**
+   * Checks that element is moving inside default time frame (200 ms)
+   *
+   * Element should implement {@link Locatable}
+   * <p>Sample: <code>$("#loginLink").shouldNot(moveAround);</code></p>
+   */
+  public static final Condition moveAround = moveAround(200);
+
+  /**
    * Checks that element is moving
    *
    * Element should implement {@link Locatable}
-   *
-   * <p>Sample: <code>$("#loginLink").shouldBe(moving);</code></p>
+   * <p>Sample: <code>$("#loginLink").should(moveAround(300));</code></p>
+   * @param
    */
-  public static final Condition moving = new Condition("moving") {
-    @Override
-    public boolean apply(WebElement element) {
-      if (!(element instanceof Locatable)) {
-        throw new RuntimeException("Provided WebElement is not Locatable, cannot understand if it moving or not");
+  public static Condition moveAround(int movePeriod) {
+    return new Condition("moveAround") {
+      @Override
+      public boolean apply(WebElement element) {
+        if (!(element instanceof Locatable)) {
+          throw new RuntimeException("Provided WebElement is not Locatable, cannot understand if it moving or not");
+        }
+        Point initialLocation = ((Locatable) element).getCoordinates().inViewPort();
+        Selenide.sleep(movePeriod);
+        Point finalLocation = ((Locatable) element).getCoordinates().inViewPort();
+        return !initialLocation.equals(finalLocation);
       }
-      Point initialLocation = ((Locatable) element).getCoordinates().inViewPort();
-      Uninterruptibles.sleepUninterruptibly(200, MILLISECONDS);
-      Point finalLocation = ((Locatable) element).getCoordinates().inViewPort();
-      return !initialLocation.equals(finalLocation);
-    }
-  };
-
+    };
+  }
   /**
    * @deprecated please use {@link #attribute(String, String)} instead
    * <p>

--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -4,10 +4,14 @@ import com.codeborne.selenide.conditions.Text;
 import com.codeborne.selenide.impl.Describe;
 import com.codeborne.selenide.impl.Html;
 import com.google.common.base.Predicate;
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.openqa.selenium.Point;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.internal.Locatable;
 
 import static com.codeborne.selenide.Selenide.getFocusedElement;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * Conditions to match web elements: checks for visibility, text etc.
@@ -100,6 +104,26 @@ public abstract class Condition implements Predicate<WebElement> {
    * <p><code>$("#loginLink").should(disappear);</code></p>
    */
   public static final Condition disappear = hidden;
+
+  /**
+   * Checks that element is moving
+   *
+   * Element should implement {@link Locatable}
+   *
+   * <p>Sample: <code>$("#loginLink").shouldBe(moving);</code></p>
+   */
+  public static final Condition moving = new Condition("moving") {
+    @Override
+    public boolean apply(WebElement element) {
+      if (!(element instanceof Locatable)) {
+        throw new RuntimeException("Provided WebElement is not Locatable, cannot understand if it moving or not");
+      }
+      Point initialLocation = ((Locatable) element).getCoordinates().inViewPort();
+      Uninterruptibles.sleepUninterruptibly(200, MILLISECONDS);
+      Point finalLocation = ((Locatable) element).getCoordinates().inViewPort();
+      return !initialLocation.equals(finalLocation);
+    }
+  };
 
   /**
    * @deprecated please use {@link #attribute(String, String)} instead

--- a/src/test/java/com/codeborne/selenide/ConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/ConditionTest.java
@@ -117,13 +117,13 @@ public class ConditionTest {
 
   @Test(expected = RuntimeException.class)
   public void elementMovingNotLocatable() {
-    Condition.moving.apply(elementWithVisibility(false));
+    Condition.moveAround.apply(elementWithVisibility(false));
   }
 
   @Test
   public void elementMoving() {
-    assertFalse(Condition.moving.apply(remoteWebElementNotMoving()));
-    assertTrue(Condition.moving.apply(remoteWebElementIsMoving()));
+    assertFalse(Condition.moveAround.apply(remoteWebElementNotMoving()));
+    assertTrue(Condition.moveAround.apply(remoteWebElementIsMoving()));
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/ConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/ConditionTest.java
@@ -1,8 +1,11 @@
 package com.codeborne.selenide;
 
 import org.junit.Test;
+import org.openqa.selenium.Point;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.internal.Coordinates;
+import org.openqa.selenium.remote.RemoteWebElement;
 
 import static com.codeborne.selenide.Condition.be;
 import static com.codeborne.selenide.Condition.not;
@@ -31,7 +34,7 @@ public class ConditionTest {
     WebElement element = elementWithText("John Malkovich The First");
     assertTrue(Condition.text("john malkovich").apply(element));
   }
-  
+
   @Test
   public void textConditionIgnoresWhitespaces() {
     assertTrue(Condition.text("john the malkovich").apply(
@@ -110,6 +113,17 @@ public class ConditionTest {
   public void elementExists() {
     assertTrue(Condition.exist.apply(elementWithVisibility(true)));
     assertTrue(Condition.exist.apply(elementWithVisibility(false)));
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void elementMovingNotLocatable() {
+    Condition.moving.apply(elementWithVisibility(false));
+  }
+
+  @Test
+  public void elementMoving() {
+    assertFalse(Condition.moving.apply(remoteWebElementNotMoving()));
+    assertTrue(Condition.moving.apply(remoteWebElementIsMoving()));
   }
 
   @Test
@@ -367,6 +381,45 @@ public class ConditionTest {
   private WebElement elementWithVisibility(boolean isVisible) {
     WebElement element = mock(WebElement.class);
     when(element.isDisplayed()).thenReturn(isVisible);
+    return element;
+  }
+
+  private Coordinates getCoordinatesWithViewPort(int x, int y) {
+    return new Coordinates() {
+      @Override
+      public Point onScreen() {
+        return null;
+      }
+
+      @Override
+      public Point inViewPort() {
+        return new Point(x, y);
+      }
+
+      @Override
+      public Point onPage() {
+        return null;
+      }
+
+      @Override
+      public Object getAuxiliary() {
+        return null;
+      }
+    };
+  }
+
+  private RemoteWebElement remoteWebElementNotMoving() {
+    RemoteWebElement element = mock(RemoteWebElement.class);
+    when(element.getCoordinates())
+      .thenReturn(getCoordinatesWithViewPort(1, 1));
+    return element;
+  }
+
+  private RemoteWebElement remoteWebElementIsMoving() {
+    RemoteWebElement element = mock(RemoteWebElement.class);
+    when(element.getCoordinates())
+      .thenReturn(getCoordinatesWithViewPort(1, 1))
+      .thenReturn(getCoordinatesWithViewPort(2, 2));
     return element;
   }
 

--- a/src/test/java/integration/ConditionMoveAroundTest.java
+++ b/src/test/java/integration/ConditionMoveAroundTest.java
@@ -1,0 +1,40 @@
+package integration;
+
+import com.codeborne.selenide.ex.ElementShouldNot;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.codeborne.selenide.Condition.moveAround;
+import static com.codeborne.selenide.Selenide.$;
+
+public class ConditionMoveAroundTest extends IntegrationTest {
+  @Before
+  public void openTestPageWithMovingElements() {
+    openFile("page_with_moving_elements.html");
+  }
+
+  @Test(expected = ElementShouldNot.class)
+  public void foreverMovingElement() {
+    $("#forever_moving_element").click();
+    $("#forever_moving_element").shouldNot(moveAround);
+  }
+
+  @Test
+  public void movingElementMoves() {
+    $("#forever_moving_element").click();
+    $("#forever_moving_element").should(moveAround);
+  }
+
+
+  @Test
+  public void notMovingElement() {
+    $("#not_moving_element").shouldNot(moveAround);
+  }
+
+
+  @Test
+  public void movingAndFrozenElement() {
+    $("#moving_then_frozen_element").click();
+    $("#moving_then_frozen_element").shouldNot(moveAround);
+  }
+}

--- a/src/test/resources/page_with_moving_elements.html
+++ b/src/test/resources/page_with_moving_elements.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Test page :: with moving elements</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+</head>
+<body>
+<script>
+  function runForever() {
+    var elem = document.getElementById("forever_moving_element");
+    var posX = 0;
+    var posY = 0;
+    setInterval(frame, 10);
+    function frame() {
+      if (posX === 0 && posY < 150) {
+        posY++;
+        elem.style.top = posX + 'px';
+        elem.style.left = posY + 'px';
+      } else if (posX < 150 && posY === 150) {
+        posX++;
+        elem.style.top = posX + 'px';
+        elem.style.left = posY + 'px';
+      } else if (posX === 150 && posY > 0) {
+        posY--;
+        elem.style.top = posX + 'px';
+        elem.style.left = posY + 'px';
+      } else if (posY === 0 && posX > 0) {
+        posX--;
+        elem.style.top = posX + 'px';
+        elem.style.left = posY + 'px';
+      }
+    }
+  }
+
+  function runLittleBit() {
+    var elem = document.getElementById("moving_then_frozen_element");
+    var pos = 0;
+    setInterval(frame, 10);
+    function frame() {
+      if (pos < 150) {
+        pos++;
+        elem.style.left = pos + 'px';
+      }
+    }
+  }
+</script>
+<div id="forever_moving_container" style="width: 200px; height: 200px; position: relative; background: yellowgreen">
+  <div id="forever_moving_element" style="width: 50px; height: 50px; position: absolute; background: red;" onclick="runForever()"></div>
+</div>
+<div id="not_moving_element" style="width: 200px; height: 20px; background: yellow"></div>
+<div id="moving_and_frozen_container" style="width: 200px; height: 50px; position: relative; background: pink">
+  <div id="moving_then_frozen_element" style="width: 50px; height: 50px; position: absolute; background: blueviolet" onclick="runLittleBit()"></div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Proposed changes
Adding new Condition - moving.
It is useful in cases when there is a moving animation and we want to click on something inside moving element. If element is moving click might not work, so we want to be sure that moving animation has finished.

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)