### PR TITLE
Stop making lots of threads

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/WebDriverThreadLocalContainer.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebDriverThreadLocalContainer.java
@@ -23,7 +23,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
@@ -286,7 +285,7 @@ public class WebDriverThreadLocalContainer implements WebDriverContainer {
 
     @Override
     public void run() {
-        closeUnusedWebdrivers();
-      }
+      closeUnusedWebdrivers();
+    }
   }
 }

--- a/src/main/java/com/codeborne/selenide/impl/WebDriverThreadLocalContainer.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebDriverThreadLocalContainer.java
@@ -264,7 +264,7 @@ public class WebDriverThreadLocalContainer implements WebDriverContainer {
     if (!cleanupThreadStarted.get()) {
       synchronized (this) {
         if (cleanupThreadStarted.compareAndSet(false, true)) {
-          pool.scheduleWithFixedDelay(new CloseUnusedWebdriversTask(), 100,100, TimeUnit.MILLISECONDS);
+          pool.scheduleWithFixedDelay(new CloseUnusedWebdriversTask(), 100, 100, TimeUnit.MILLISECONDS);
         }
       }
     }


### PR DESCRIPTION
## Proposed changes
Every time a webdriver is closed, a new thread is created and quickly destroyed.  This pull request creates a single long-lived Executor (thread) instead.

