### PR TITLE
Add ability to get browser mob proxy instance.

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -15,7 +15,9 @@ dependencies {
     exclude group: 'org.apache.httpcomponents', module: 'httpcore'
     exclude group: 'net.sourceforge.htmlunit', module: 'htmlunit'
   }
-  implementation('io.github.bonigarcia:webdrivermanager:2.2.1')
+  implementation('io.github.bonigarcia:webdrivermanager:2.2.1') {
+    exclude group: 'ch.qos.logback', module: 'logback-classic'
+  }
   implementation('org.apache.httpcomponents:httpcore:4.4.9')
   implementation('com.google.code.gson:gson:2.8.2')
   implementation('com.google.guava:guava:24.1-jre')
@@ -35,9 +37,9 @@ dependencies {
 
   testImplementation('org.seleniumhq.selenium:selenium-server:3.11.0') { transitive = false }
   testImplementation('org.mockito:mockito-core:2.18.0')
-  testCompile 'org.seleniumhq.selenium:jetty-repacked:9.4.7.v20170914'
-  testCompile 'org.eclipse.jetty:jetty-server:9.4.7.v20170914'
-  testCompile 'org.eclipse.jetty:jetty-servlet:9.4.7.v20170914'
+  testImplementation('org.seleniumhq.selenium:jetty-repacked:9.4.7.v20170914')
+  testImplementation('org.eclipse.jetty:jetty-server:9.4.7.v20170914')
+  testImplementation('org.eclipse.jetty:jetty-servlet:9.4.7.v20170914')
   testImplementation('commons-fileupload:commons-fileupload:1.3.3')
   testImplementation('com.automation-remarks:video-recorder-core:1.4.1')
   testImplementation('com.automation-remarks:video-recorder-junit:1.4.1')

--- a/src/main/java/com/codeborne/selenide/proxy/SelenideProxyServer.java
+++ b/src/main/java/com/codeborne/selenide/proxy/SelenideProxyServer.java
@@ -22,6 +22,7 @@ import static java.lang.Integer.parseInt;
  */
 public class SelenideProxyServer {
   protected final Proxy outsideProxy;
+
   protected BrowserMobProxy proxy = new BrowserMobProxyServer() {
     int maxSize = 64 * 1024 * 1024; // 64 MB
     @Override
@@ -33,6 +34,15 @@ public class SelenideProxyServer {
       addLastHttpFilterFactory(new ResponseFilterAdapter.FilterSource(filter, maxSize));
     }
   };
+
+  /**
+   * Method return current instance of browser mob proxy
+   *
+   * @return browser mob proxy instance
+   */
+  public BrowserMobProxy getProxy() {
+    return proxy;
+  }
 
   protected int port;
   protected Map<String, RequestFilter> requestFilters = new HashMap<>();


### PR DESCRIPTION
* Simplify and extend proxy test.
* Exclude provided by webdrivermanager logback-classic module.
* Use new testImplementation scope instead of old testCompile.

## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)