### PR TITLE
Redirect tons of firefox logs to /dev/null

### DIFF
--- a/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
@@ -23,6 +23,7 @@ class FirefoxDriverFactory extends AbstractDriverFactory {
 
   @Override
   WebDriver create(final Proxy proxy) {
+    System.setProperty(FirefoxDriver.SystemProperty.BROWSER_LOGFILE, "/dev/null");
     return createFirefoxDriver(proxy);
   }
 

--- a/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
@@ -23,7 +23,8 @@ class FirefoxDriverFactory extends AbstractDriverFactory {
 
   @Override
   WebDriver create(final Proxy proxy) {
-    System.setProperty(FirefoxDriver.SystemProperty.BROWSER_LOGFILE, "/dev/null");
+    String logFilePath = System.getProperty(FirefoxDriver.SystemProperty.BROWSER_LOGFILE, "/dev/null");
+    System.setProperty(FirefoxDriver.SystemProperty.BROWSER_LOGFILE, logFilePath);
     return createFirefoxDriver(proxy);
   }
 

--- a/src/main/java/com/codeborne/selenide/webdriver/LegacyFirefoxDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/LegacyFirefoxDriverFactory.java
@@ -19,6 +19,7 @@ class LegacyFirefoxDriverFactory extends FirefoxDriverFactory {
 
   @Override
   WebDriver create(final Proxy proxy) {
+    System.setProperty(FirefoxDriver.SystemProperty.BROWSER_LOGFILE, "/dev/null");
     return createLegacyFirefoxDriver(proxy);
   }
 

--- a/src/main/java/com/codeborne/selenide/webdriver/LegacyFirefoxDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/LegacyFirefoxDriverFactory.java
@@ -19,7 +19,8 @@ class LegacyFirefoxDriverFactory extends FirefoxDriverFactory {
 
   @Override
   WebDriver create(final Proxy proxy) {
-    System.setProperty(FirefoxDriver.SystemProperty.BROWSER_LOGFILE, "/dev/null");
+    String logFilePath = System.getProperty(FirefoxDriver.SystemProperty.BROWSER_LOGFILE, "/dev/null");
+    System.setProperty(FirefoxDriver.SystemProperty.BROWSER_LOGFILE, logFilePath);
     return createLegacyFirefoxDriver(proxy);
   }
 


### PR DESCRIPTION
## Proposed changes
Generally this PR addressed to #673 
Linked with firefox [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1399441) that still open
Selenium bug - https://github.com/SeleniumHQ/selenium/issues/2632
And geckodriver bug - https://github.com/mozilla/geckodriver/issues/619

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)