### PR TITLE
Use selenium refresh for selenide refresh instead of reopen current url.

### DIFF
--- a/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/src/main/java/com/codeborne/selenide/Selenide.java
@@ -35,7 +35,6 @@ import static com.codeborne.selenide.WebDriverRunner.getWebDriver;
 import static com.codeborne.selenide.WebDriverRunner.hasWebDriverStarted;
 import static com.codeborne.selenide.WebDriverRunner.supportsJavascript;
 import static com.codeborne.selenide.WebDriverRunner.supportsModalDialogs;
-import static com.codeborne.selenide.WebDriverRunner.url;
 import static com.codeborne.selenide.impl.WebElementWrapper.wrap;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -186,7 +185,7 @@ public class Selenide {
    * Reload current page
    */
   public static void refresh() {
-    navigator.open(url());
+    navigator.refresh();
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/impl/Navigator.java
+++ b/src/main/java/com/codeborne/selenide/impl/Navigator.java
@@ -136,4 +136,8 @@ public class Navigator {
   public void forward() {
     getWebDriver().navigate().forward();
   }
+
+  public void refresh() {
+    getWebDriver().navigate().refresh();
+  }
 }


### PR DESCRIPTION
## Proposed changes
Use selenium refresh for selenide refresh instead of reopen current url.
Fix #740 issue.

## Checklist
- [ ] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)