### PR TITLE
#695 Do not open a browser if `Configuration.reopenBrowserOnFail` is …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 4.12.2
-*
+* #695 Do not open a browser if `Configuration.reopenBrowserOnFail` is `false` and user has not set webdriver manually 
 
 ## 4.12.1 (released 02.06.2018)
 

--- a/src/main/java/com/codeborne/selenide/impl/WebDriverThreadLocalContainer.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebDriverThreadLocalContainer.java
@@ -214,6 +214,11 @@ public class WebDriverThreadLocalContainer implements WebDriverContainer {
   }
 
   protected WebDriver createDriver() {
+    if (!reopenBrowserOnFail) {
+      throw new IllegalStateException("No webdriver is bound to current thread: " + currentThread().getId() +
+        ", and cannot create a new webdriver because Configuration.reopenBrowserOnFail=false");
+    }
+
     Proxy userProvidedProxy = proxy;
 
     if (Configuration.fileDownload == PROXY) {


### PR DESCRIPTION
…`false` and user has not set webdriver manually

## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)