### PR TITLE
Implementing a way of retrieving the maxlength value

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -170,6 +170,13 @@ public interface SelenideElement extends WebElement, FindsByLinkText, FindsById,
   String name();
 
   /**
+   * Get the 'maxlength' attribute of the element
+   * @return attribute 'maxlength' value or null if attribute is missing
+   * @see com.codeborne.selenide.commands.GetMaxLength
+   */
+  String maxLength();
+
+  /**
    * Get the "value" attribute of the element
    * Same as #getValue()
    * @return attribute "value" value or null if attribute is missing

--- a/src/main/java/com/codeborne/selenide/commands/Commands.java
+++ b/src/main/java/com/codeborne/selenide/commands/Commands.java
@@ -66,6 +66,7 @@ public class Commands {
     add("name", new GetName());
     add("text", new GetText());
     add("getValue", new GetValue());
+    add("getMaxLength", new GetMaxLength());
   }
 
   private void addClickCommands() {

--- a/src/main/java/com/codeborne/selenide/commands/Commands.java
+++ b/src/main/java/com/codeborne/selenide/commands/Commands.java
@@ -66,7 +66,7 @@ public class Commands {
     add("name", new GetName());
     add("text", new GetText());
     add("getValue", new GetValue());
-    add("getMaxLength", new GetMaxLength());
+    add("maxLength", new GetMaxLength());
   }
 
   private void addClickCommands() {

--- a/src/main/java/com/codeborne/selenide/commands/GetMaxLength.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetMaxLength.java
@@ -1,0 +1,13 @@
+package com.codeborne.selenide.commands;
+
+import com.codeborne.selenide.Command;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+
+public class GetMaxLength implements Command<String> {
+
+  @Override
+  public String execute(final SelenideElement proxy, final WebElementSource locator, final Object[] args) {
+    return locator.getWebElement().getAttribute("maxlength");
+  }
+}

--- a/src/test/java/com/codeborne/selenide/commands/GetMaxLengthCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetMaxLengthCommandTest.java
@@ -1,0 +1,37 @@
+package com.codeborne.selenide.commands;
+
+
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class GetMaxLengthCommandTest implements WithAssertions {
+  private SelenideElement mockedElement;
+  private SelenideElement proxy;
+  private WebElementSource locator;
+  private GetMaxLength getMaxLengthCommand;
+
+  @BeforeEach
+  void setup() {
+    getMaxLengthCommand = new GetMaxLength();
+    proxy = mock(SelenideElement.class);
+    mockedElement = mock(SelenideElement.class);
+    locator = mock(WebElementSource.class);
+    when(locator.getWebElement()).thenReturn(mockedElement);
+  }
+
+  @Test
+  void testExecuteMethod() {
+    String argument = "class";
+    String elementAttribute = "hello";
+    when(mockedElement.getAttribute("maxlength")).thenReturn(elementAttribute);
+    assertThat(getMaxLengthCommand.execute(proxy, locator, new Object[] {argument, "something else"}))
+      .isEqualTo(elementAttribute);
+  }
+
+}

--- a/src/test/java/integration/AttributeTest.java
+++ b/src/test/java/integration/AttributeTest.java
@@ -52,6 +52,8 @@ public class AttributeTest extends IntegrationTest {
       .isEqualTo("username");
     assertThat($(byAttribute("http-equiv", "Content-Type")).getTagName())
       .isEqualTo("meta");
+    assertThat($(byAttribute("maxlength", "25")).getTagName())
+      .isEqualTo("input");
   }
 
   @Test

--- a/src/test/java/integration/AttributeTest.java
+++ b/src/test/java/integration/AttributeTest.java
@@ -67,6 +67,12 @@ public class AttributeTest extends IntegrationTest {
   }
 
   @Test
+  void userCanGetMaxLengthAttribute() {
+    assertThat($(by("readonly", "readonly")).maxLength())
+      .isEqualTo("25");
+  }
+
+  @Test
   void userCanGetDataAttributes() {
     assertThat($(byValue("livemail.ru")).getAttribute("data-mailServerId"))
       .isEqualTo("111");

--- a/src/test/resources/page_with_selects_without_jquery.html
+++ b/src/test/resources/page_with_selects_without_jquery.html
@@ -122,7 +122,7 @@
   <form action="#submitted-form" method="post">
     <fieldset title="Login form">
       <label> Username:
-        <input name="username" value="" readonly="readonly"/>
+        <input name="username" value="" readonly="readonly" maxlength="25"/>
       </label> <br/>
       <label>Password:
         <input name="password" value="" maxlength="24"/>


### PR DESCRIPTION
## Proposed changes
Adding a simple means of retrieving the maxlength attribute value of a given webelement

## Checklist
- [ ] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)