### PR TITLE
#273 throw NoAlertPresentException, NoSuchWindowException, or NoSuchF…

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideTargetLocator.java
+++ b/src/main/java/com/codeborne/selenide/SelenideTargetLocator.java
@@ -76,7 +76,7 @@ public class SelenideTargetLocator implements TargetLocator {
     try {
       return Wait().until(alertIsPresent());
     } catch (TimeoutException e) {
-      throw new NoAlertPresentException();
+      throw new NoAlertPresentException(e);
     }
   }
 
@@ -171,7 +171,7 @@ public class SelenideTargetLocator implements TargetLocator {
       return Wait().until(windowToBeAvailableAndSwitchToIt(index));
     }
     catch (TimeoutException e) {
-      throw new NoSuchWindowException("Window with index not found: " + index);
+      throw new NoSuchWindowException("Window with index not found: " + index, e);
     }
   }
 

--- a/src/main/java/com/codeborne/selenide/SelenideTargetLocator.java
+++ b/src/main/java/com/codeborne/selenide/SelenideTargetLocator.java
@@ -34,7 +34,7 @@ public class SelenideTargetLocator implements TargetLocator {
     try {
       return Wait().until(frameToBeAvailableAndSwitchToIt(index));
     } catch (NoSuchElementException | TimeoutException e) {
-      throw new NoSuchFrameException("Frame with index not found: " + index, e);
+      throw new NoSuchFrameException("No frame found with index: " + index, e);
     }
   }
 
@@ -43,7 +43,7 @@ public class SelenideTargetLocator implements TargetLocator {
     try {
       return Wait().until(frameToBeAvailableAndSwitchToIt(nameOrId));
     } catch (NoSuchElementException | TimeoutException e) {
-      throw new NoSuchFrameException("No frame found with id/name = " + nameOrId, e);
+      throw new NoSuchFrameException("No frame found with id/name: " + nameOrId, e);
     }
   }
 
@@ -52,7 +52,7 @@ public class SelenideTargetLocator implements TargetLocator {
     try {
       return Wait().until(frameToBeAvailableAndSwitchToIt(frameElement));
     } catch (NoSuchElementException | TimeoutException e) {
-      throw new NoSuchFrameException("No frame found = " + frameElement, e);
+      throw new NoSuchFrameException("No frame found with element: " + frameElement, e);
     }
   }
 
@@ -76,7 +76,7 @@ public class SelenideTargetLocator implements TargetLocator {
     try {
       return Wait().until(alertIsPresent());
     } catch (TimeoutException e) {
-      throw new NoAlertPresentException(e);
+      throw new NoAlertPresentException("Alert not found", e);
     }
   }
 
@@ -171,7 +171,7 @@ public class SelenideTargetLocator implements TargetLocator {
       return Wait().until(windowToBeAvailableAndSwitchToIt(index));
     }
     catch (TimeoutException e) {
-      throw new NoSuchWindowException("Window with index not found: " + index, e);
+      throw new NoSuchWindowException("No window found with index: " + index, e);
     }
   }
 
@@ -183,8 +183,8 @@ public class SelenideTargetLocator implements TargetLocator {
   public WebDriver window(String nameOrHandleOrTitle) {
     try {
       return Wait().until(windowToBeAvailableAndSwitchToIt(nameOrHandleOrTitle));
-    } catch (NoSuchWindowException | TimeoutException e) {
-      return windowByTitle(nameOrHandleOrTitle);
+    } catch (TimeoutException e) {
+      throw new NoSuchWindowException("No window found with name or handle or title: " + nameOrHandleOrTitle, e);
     }
   }
 

--- a/src/test/java/integration/AlertTest.java
+++ b/src/test/java/integration/AlertTest.java
@@ -87,20 +87,20 @@ class AlertTest extends IntegrationTest {
   void alertThrowsNoAlertPresentExceptionWhenAlertIsNotPresent() {
     assertThatThrownBy(() -> {
       switchTo().alert();
-    }).isInstanceOf(NoAlertPresentException.class);
+    }).isInstanceOf(NoAlertPresentException.class).hasMessage("Alert not found");
   }
 
   @Test
   void confirmThrowsNoAlertPresentExceptionWhenAlertIsNotPresent() {
     assertThatThrownBy(() -> {
       confirm();
-    }).isInstanceOf(NoAlertPresentException.class);
+    }).isInstanceOf(NoAlertPresentException.class).hasMessage("Alert not found");
   }
 
   @Test
   void promptThrowsNoAlertPresentExceptionWhenAlertIsNotPresent() {
     assertThatThrownBy(() -> {
       prompt();
-    }).isInstanceOf(NoAlertPresentException.class);
+    }).isInstanceOf(NoAlertPresentException.class).hasMessage("Alert not found");
   }
 }

--- a/src/test/java/integration/AlertTest.java
+++ b/src/test/java/integration/AlertTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoAlertPresentException;
 
 import static com.codeborne.selenide.Condition.empty;
 import static com.codeborne.selenide.Condition.text;
@@ -80,5 +81,26 @@ class AlertTest extends IntegrationTest {
     prompt("Медленный Барри");
     $("#message").shouldHave(text("Hello, Медленный Барри!"));
     $("#container").shouldBe(empty);
+  }
+
+  @Test
+  void alertThrowsNoAlertPresentExceptionWhenAlertIsNotPresent() {
+    assertThatThrownBy(() -> {
+      switchTo().alert();
+    }).isInstanceOf(NoAlertPresentException.class);
+  }
+
+  @Test
+  void confirmThrowsNoAlertPresentExceptionWhenAlertIsNotPresent() {
+    assertThatThrownBy(() -> {
+      confirm();
+    }).isInstanceOf(NoAlertPresentException.class);
+  }
+
+  @Test
+  void promptThrowsNoAlertPresentExceptionWhenAlertIsNotPresent() {
+    assertThatThrownBy(() -> {
+      prompt();
+    }).isInstanceOf(NoAlertPresentException.class);
   }
 }

--- a/src/test/java/integration/FramesTest.java
+++ b/src/test/java/integration/FramesTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.NoSuchFrameException;
 
 import static com.codeborne.selenide.Condition.name;
 import static com.codeborne.selenide.Condition.text;
@@ -104,5 +105,37 @@ class FramesTest extends IntegrationTest {
     switchTo().defaultContent();
     switchTo().frame(2);
     $("h1").shouldHave(text("Page with JQuery"));
+  }
+
+
+  @Test
+  void throwsNoSuchFrameExceptionWhenSwitchingToAbsentFrameByElement() {
+    assertThat(title())
+      .isEqualTo("Test::frames");
+
+    assertThatThrownBy(() -> {
+      switchTo().frame("mainFrame");
+      // $("#log") is present, but not frame.
+      switchTo().frame($("#log"));
+    }).isInstanceOf(NoSuchFrameException.class);
+  }
+
+  @Test
+  void throwsNoSuchFrameExceptionWhenSwitchingToAbsentFrameByTitle() {
+    assertThat(title())
+      .isEqualTo("Test::frames");
+    assertThatThrownBy(() -> {
+      switchTo().frame("absentFrame");
+    }).isInstanceOf(NoSuchFrameException.class);
+  }
+
+  @Test
+  void throwsNoSuchFrameExceptionWhenSwitchingToAbsentFrameByIndex() {
+    assertThat(title())
+      .isEqualTo("Test::frames");
+
+    assertThatThrownBy(() -> {
+      switchTo().frame(Integer.MAX_VALUE);
+    }).isInstanceOf(NoSuchFrameException.class);
   }
 }

--- a/src/test/java/integration/FramesTest.java
+++ b/src/test/java/integration/FramesTest.java
@@ -15,6 +15,7 @@ import static com.codeborne.selenide.Selenide.switchTo;
 import static com.codeborne.selenide.Selenide.title;
 import static com.codeborne.selenide.WebDriverRunner.currentFrameUrl;
 import static com.codeborne.selenide.WebDriverRunner.isChrome;
+import static com.codeborne.selenide.WebDriverRunner.isHtmlUnit;
 import static com.codeborne.selenide.WebDriverRunner.source;
 
 class FramesTest extends IntegrationTest {
@@ -110,6 +111,7 @@ class FramesTest extends IntegrationTest {
 
   @Test
   void throwsNoSuchFrameExceptionWhenSwitchingToAbsentFrameByElement() {
+    Assumptions.assumeFalse(isHtmlUnit());
     assertThat(title())
       .isEqualTo("Test::frames");
 
@@ -117,7 +119,7 @@ class FramesTest extends IntegrationTest {
       switchTo().frame("mainFrame");
       // $("#log") is present, but not frame.
       switchTo().frame($("#log"));
-    }).isInstanceOf(NoSuchFrameException.class);
+    }).isInstanceOf(NoSuchFrameException.class).hasMessage("No frame found with element: <div id=\"log\" displayed:false></div>");
   }
 
   @Test
@@ -126,7 +128,7 @@ class FramesTest extends IntegrationTest {
       .isEqualTo("Test::frames");
     assertThatThrownBy(() -> {
       switchTo().frame("absentFrame");
-    }).isInstanceOf(NoSuchFrameException.class);
+    }).isInstanceOf(NoSuchFrameException.class).hasMessage("No frame found with id/name: absentFrame");
   }
 
   @Test
@@ -136,6 +138,6 @@ class FramesTest extends IntegrationTest {
 
     assertThatThrownBy(() -> {
       switchTo().frame(Integer.MAX_VALUE);
-    }).isInstanceOf(NoSuchFrameException.class);
+    }).isInstanceOf(NoSuchFrameException.class).hasMessage("No frame found with index: " + Integer.MAX_VALUE);
   }
 }

--- a/src/test/java/integration/TabsTest.java
+++ b/src/test/java/integration/TabsTest.java
@@ -156,7 +156,7 @@ class TabsTest extends IntegrationTest {
 
     assertThatThrownBy(() -> {
       switchTo().window("absentWindow");
-    }).isInstanceOf(NoSuchWindowException.class);
+    }).isInstanceOf(NoSuchWindowException.class).hasMessage("No window found with name or handle or title: absentWindow");
   }
 
   @Test
@@ -166,7 +166,7 @@ class TabsTest extends IntegrationTest {
 
     assertThatThrownBy(() -> {
       switchTo().window(Integer.MAX_VALUE);
-    }).isInstanceOf(NoSuchWindowException.class);
+    }).isInstanceOf(NoSuchWindowException.class).hasMessage("No window found with index: " + Integer.MAX_VALUE);
   }
 
   @AfterEach

--- a/src/test/java/integration/TabsTest.java
+++ b/src/test/java/integration/TabsTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.NoSuchWindowException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
@@ -17,6 +18,7 @@ import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.Wait;
 import static com.codeborne.selenide.Selenide.close;
 import static com.codeborne.selenide.Selenide.switchTo;
+import static com.codeborne.selenide.Selenide.title;
 import static com.codeborne.selenide.WebDriverRunner.getWebDriver;
 import static com.codeborne.selenide.WebDriverRunner.isChrome;
 import static com.codeborne.selenide.WebDriverRunner.isHtmlUnit;
@@ -145,6 +147,26 @@ class TabsTest extends IntegrationTest {
 //    $("body").shouldHave(text("Secret phrase 3"));
 //
 //    switchTo().window("Test::tabs"); $("h1").shouldHave(text("Tabs"));
+  }
+
+  @Test
+  void throwsNoSuchWindowExceptionWhenSwitchingToAbsentWindowByTitle() {
+    assertThat(title())
+      .isEqualTo("Test::tabs");
+
+    assertThatThrownBy(() -> {
+      switchTo().window("absentWindow");
+    }).isInstanceOf(NoSuchWindowException.class);
+  }
+
+  @Test
+  void throwsNoSuchWindowExceptionWhenSwitchingToAbsentWindowByIndex() {
+    assertThat(title())
+      .isEqualTo("Test::tabs");
+
+    assertThatThrownBy(() -> {
+      switchTo().window(Integer.MAX_VALUE);
+    }).isInstanceOf(NoSuchWindowException.class);
   }
 
   @AfterEach


### PR DESCRIPTION
…rameException instead of TimeoutException

## Proposed changes
Fow now, `switchTo().alert()` throws TimeoutException as well as `switchTo().frame()` and `switchTo().window()` do.
I think these methods should throw `NoAlertPresentException`, `NoSuchFramePresentException`, or `NoSuchWindowPresentException` respectively.

This PR is related to #273.

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)