### PR TITLE
Fix misleading error message $.selectOptionByValue() reports

### DIFF
--- a/src/main/java/com/codeborne/selenide/commands/SelectOptionByValue.java
+++ b/src/main/java/com/codeborne/selenide/commands/SelectOptionByValue.java
@@ -1,9 +1,12 @@
 package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.Command;
+import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.ex.ElementNotFound;
 import com.codeborne.selenide.impl.WebElementSource;
 
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.support.ui.Select;
 
 public class SelectOptionByValue implements Command {
@@ -11,11 +14,19 @@ public class SelectOptionByValue implements Command {
   public Object execute(SelenideElement proxy, WebElementSource selectField, Object[] args) {
     Select select = new Select(selectField.getWebElement());
     if (args[0] instanceof String) {
-      select.selectByValue((String) args[0]);
+      try {
+        select.selectByValue((String) args[0]);
+      } catch (NoSuchElementException e) {
+        throw new ElementNotFound("Cannot locate option with value: @" + (String) args[0], Condition.exist, e);
+      }
     } else if (args[0] instanceof String[]) {
       String[] values = (String[]) args[0];
       for (String value : values) {
-        select.selectByValue(value);
+        try {
+          select.selectByValue(value);
+        } catch (NoSuchElementException e) {
+          throw new ElementNotFound("Cannot locate option with value: @" + value, Condition.exist, e);
+        }
       }
     }
     return null;

--- a/src/test/java/com/codeborne/selenide/commands/SelectionOptionByValueCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/SelectionOptionByValueCommandTest.java
@@ -9,12 +9,9 @@ import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
-import org.openqa.selenium.NoAlertPresentException;
-import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.Quotes;
 
-import static com.codeborne.selenide.Selenide.prompt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/com/codeborne/selenide/commands/SelectionOptionByValueCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/SelectionOptionByValueCommandTest.java
@@ -3,15 +3,18 @@ package com.codeborne.selenide.commands;
 import java.util.Collections;
 
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.ex.ElementNotFound;
 import com.codeborne.selenide.impl.WebElementSource;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoAlertPresentException;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.Quotes;
 
+import static com.codeborne.selenide.Selenide.prompt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -64,11 +67,9 @@ class SelectionOptionByValueCommandTest implements WithAssertions {
     when(mockedElement.findElements(By.xpath(
       ".//option[@value = " + Quotes.escape(defaultElementValue) + "]")))
       .thenReturn(Collections.emptyList());
-    try {
+    assertThatThrownBy(() -> {
       selectOptionByValueCommand.execute(proxy, selectField, new Object[]{new String[]{defaultElementValue}});
-    } catch (NoSuchElementException exception) {
-      assertThat(exception)
-        .hasMessageContaining(String.format("Cannot locate option with value: %s", defaultElementValue));
-    }
+    }).isInstanceOf(ElementNotFound.class)
+      .hasMessage(String.format("Element not found {Cannot locate option with value: @%s}\nExpected: exist", defaultElementValue));
   }
 }


### PR DESCRIPTION
## Proposed changes
Hi, Selenium maintainers!

As @asolntsev described in #709, $.selectOptionByValue() reports a misleading error message.
So I fixed  `selectOptionByValue` referring to `selectOptionByTextOrIndex` and `selectOptionContainingText`.

This PR is related to #709 .

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)