### PR TITLE
Fix #784 Enable BasicAuth through Selenide proxy server

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -57,7 +57,7 @@
     <module name="UnnecessaryParentheses"/>
     <!--<module name="MutableException"/>-->
     <module name="ClassFanOutComplexity">
-      <property name="max" value="28"/>
+      <property name="max" value="31"/>
     </module>
     <module name="CyclomaticComplexity">
       <property name="max" value="20"/>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -57,7 +57,7 @@
     <module name="UnnecessaryParentheses"/>
     <!--<module name="MutableException"/>-->
     <module name="ClassFanOutComplexity">
-      <property name="max" value="31"/>
+      <property name="max" value="29"/>
     </module>
     <module name="CyclomaticComplexity">
       <property name="max" value="20"/>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -57,7 +57,7 @@
     <module name="UnnecessaryParentheses"/>
     <!--<module name="MutableException"/>-->
     <module name="ClassFanOutComplexity">
-      <property name="max" value="29"/>
+      <property name="max" value="30"/>
     </module>
     <module name="CyclomaticComplexity">
       <property name="max" value="20"/>

--- a/src/main/java/com/codeborne/selenide/AuthenticationType.java
+++ b/src/main/java/com/codeborne/selenide/AuthenticationType.java
@@ -1,0 +1,25 @@
+package com.codeborne.selenide;
+
+/**
+ * Authentication schemes.
+ *
+ * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#Authentication_schemes">Web HTTP reference</a>
+ */
+public enum AuthenticationType {
+  BASIC("Basic"),
+  BEARER("Bearer"),
+  DIGEST("Digest"),
+  HOBA("HOBA"),
+  MUTUAL("Mutual"),
+  AWS4_HMAC_SHA256("AWS4-HMAC-SHA256");
+
+  private String value;
+
+  AuthenticationType(final String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+}

--- a/src/main/java/com/codeborne/selenide/AuthenticationType.java
+++ b/src/main/java/com/codeborne/selenide/AuthenticationType.java
@@ -13,9 +13,9 @@ public enum AuthenticationType {
   MUTUAL("Mutual"),
   AWS4_HMAC_SHA256("AWS4-HMAC-SHA256");
 
-  private String value;
+  private final String value;
 
-  AuthenticationType(final String value) {
+  AuthenticationType(String value) {
     this.value = value;
   }
 

--- a/src/main/java/com/codeborne/selenide/Credentials.java
+++ b/src/main/java/com/codeborne/selenide/Credentials.java
@@ -4,11 +4,11 @@ import java.util.Base64;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-final class Credentials {
+public final class Credentials {
   private String login;
   private String password;
 
-  Credentials(final String login, final String password) {
+  public Credentials(final String login, final String password) {
     this.login = login;
     this.password = password;
   }
@@ -18,7 +18,7 @@ final class Credentials {
    *
    * @return encoded string
    */
-  String encode() {
+  public String encode() {
     final byte[] credentialsBytes = combine().getBytes(UTF_8);
     return Base64.getEncoder().encodeToString(credentialsBytes);
   }

--- a/src/main/java/com/codeborne/selenide/Credentials.java
+++ b/src/main/java/com/codeborne/selenide/Credentials.java
@@ -5,10 +5,10 @@ import java.util.Base64;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public final class Credentials {
-  private String login;
-  private String password;
+  private final String login;
+  private final String password;
 
-  public Credentials(final String login, final String password) {
+  public Credentials(String login, String password) {
     this.login = login;
     this.password = password;
   }
@@ -19,15 +19,10 @@ public final class Credentials {
    * @return encoded string
    */
   public String encode() {
-    final byte[] credentialsBytes = combine().getBytes(UTF_8);
+    byte[] credentialsBytes = combine().getBytes(UTF_8);
     return Base64.getEncoder().encodeToString(credentialsBytes);
   }
 
-  /**
-   * Combine credentials with a colon (login:password).
-   *
-   * @return combined credentials
-   */
   private String combine() {
     return String.format("%s:%s", login, password);
   }

--- a/src/main/java/com/codeborne/selenide/Credentials.java
+++ b/src/main/java/com/codeborne/selenide/Credentials.java
@@ -1,0 +1,34 @@
+package com.codeborne.selenide;
+
+import java.util.Base64;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+final class Credentials {
+  private String login;
+  private String password;
+
+  Credentials(final String login, final String password) {
+    this.login = login;
+    this.password = password;
+  }
+
+  /**
+   * The resulting string is base64 encoded (YWxhZGRpbjpvcGVuc2VzYW1l).
+   *
+   * @return encoded string
+   */
+  String encode() {
+    final byte[] credentialsBytes = combine().getBytes(UTF_8);
+    return Base64.getEncoder().encodeToString(credentialsBytes);
+  }
+
+  /**
+   * Combine credentials with a colon (login:password).
+   *
+   * @return combined credentials
+   */
+  private String combine() {
+    return String.format("%s:%s", login, password);
+  }
+}

--- a/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/src/main/java/com/codeborne/selenide/Selenide.java
@@ -9,7 +9,6 @@ import com.codeborne.selenide.impl.Navigator;
 import com.codeborne.selenide.impl.SelenideFieldDecorator;
 import com.codeborne.selenide.impl.WebElementsCollectionWrapper;
 
-import net.lightbody.bmp.BrowserMobProxy;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
@@ -39,8 +38,6 @@ import static com.codeborne.selenide.Configuration.dismissModalDialogs;
 import static com.codeborne.selenide.Configuration.pollingInterval;
 import static com.codeborne.selenide.Configuration.timeout;
 import static com.codeborne.selenide.WebDriverRunner.closeWebDriver;
-import static com.codeborne.selenide.WebDriverRunner.getAndCheckWebDriver;
-import static com.codeborne.selenide.WebDriverRunner.getSelenideProxy;
 import static com.codeborne.selenide.WebDriverRunner.getWebDriver;
 import static com.codeborne.selenide.WebDriverRunner.hasWebDriverStarted;
 import static com.codeborne.selenide.WebDriverRunner.supportsJavascript;
@@ -122,15 +119,8 @@ public class Selenide {
    * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Proxy-Authorization">Web HTTP reference</a>
    * @see AuthenticationType
    */
-  public static void open(final String relativeOrAbsoluteUrl, final AuthenticationType authenticationType,
-                          final String login, final String password) {
-    getAndCheckWebDriver();
-    final BrowserMobProxy proxy = getSelenideProxy().getProxy();
-    final Credentials credentials = new Credentials(login, password);
-    final String authorization = String.format("%s %s", authenticationType.getValue(), credentials.encode());
-    proxy.addHeader("Authorization", authorization);
-    proxy.addHeader("Proxy-Authorization", authorization);
-    navigator.open(relativeOrAbsoluteUrl);
+  public static void open(String relativeOrAbsoluteUrl, AuthenticationType authenticationType, String login, String password) {
+    navigator.open(relativeOrAbsoluteUrl, authenticationType, login, password);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/src/main/java/com/codeborne/selenide/Selenide.java
@@ -83,18 +83,16 @@ public class Selenide {
 
   /**
    * The main starting point in your tests.
+   * <p>
    * Open a browser window with given URL and credentials for basic authentication
-   *
+   * <p>
    * If browser window was already opened before, it will be reused.
-   *
+   * <p>
    * Don't bother about closing the browser - it will be closed automatically when all your tests are done.
-   *
-   * @param relativeOrAbsoluteUrl
-   * @param domain
-   * @param login
-   * @param password
-   *   If not starting with "http://" or "https://" or "file://", it's considered to be relative URL.
-   *   In this case, it's prepended by baseUrl
+   * <p>
+   * If not starting with "http://" or "https://" or "file://", it's considered to be relative URL.
+   * <p>
+   * In this case, it's prepended by baseUrl
    */
   public static void open(String relativeOrAbsoluteUrl, String domain, String login, String password) {
     navigator.open(relativeOrAbsoluteUrl, domain, login, password);
@@ -102,25 +100,37 @@ public class Selenide {
   }
 
   /**
-   *
    * The main starting point in your tests.
    * <p>
    * Open browser and pass authentication using build-in proxy.
    * <p>
    * A common authenticationType is "Basic". See Web HTTP reference for other types.
    * <p>
-   * {@code Configuration.fileDownload == Configuration.FileDownloadMode.PROXY;} - is required configuration.
-   *
-   * @param relativeOrAbsoluteUrl
-   * @param authenticationType
-   * @param login
-   * @param password
+   * This method can only work if - {@code Configuration.fileDownload == Configuration.FileDownloadMode.PROXY;}
    *
    * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Proxy-Authorization">Web HTTP reference</a>
    * @see AuthenticationType
    */
   public static void open(String relativeOrAbsoluteUrl, AuthenticationType authenticationType, String login, String password) {
-    navigator.open(relativeOrAbsoluteUrl, authenticationType, login, password);
+    Credentials credentials = new Credentials(login, password);
+    open(relativeOrAbsoluteUrl, authenticationType, credentials);
+  }
+
+  /**
+   * The main starting point in your tests.
+   * <p>
+   * Open browser and pass authentication using build-in proxy.
+   * <p>
+   * A common authenticationType is "Basic". See Web HTTP reference for other types.
+   * <p>
+   * This method can only work if - {@code Configuration.fileDownload == Configuration.FileDownloadMode.PROXY;}
+   *
+   * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Proxy-Authorization">Web HTTP reference</a>
+   * @see AuthenticationType
+   * @see Credentials
+   */
+  public static void open(String relativeOrAbsoluteUrl, AuthenticationType authenticationType, Credentials credentials) {
+    navigator.open(relativeOrAbsoluteUrl, authenticationType, credentials);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/src/main/java/com/codeborne/selenide/Selenide.java
@@ -9,6 +9,7 @@ import com.codeborne.selenide.impl.Navigator;
 import com.codeborne.selenide.impl.SelenideFieldDecorator;
 import com.codeborne.selenide.impl.WebElementsCollectionWrapper;
 
+import net.lightbody.bmp.BrowserMobProxy;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
@@ -38,6 +39,8 @@ import static com.codeborne.selenide.Configuration.dismissModalDialogs;
 import static com.codeborne.selenide.Configuration.pollingInterval;
 import static com.codeborne.selenide.Configuration.timeout;
 import static com.codeborne.selenide.WebDriverRunner.closeWebDriver;
+import static com.codeborne.selenide.WebDriverRunner.getAndCheckWebDriver;
+import static com.codeborne.selenide.WebDriverRunner.getSelenideProxy;
 import static com.codeborne.selenide.WebDriverRunner.getWebDriver;
 import static com.codeborne.selenide.WebDriverRunner.hasWebDriverStarted;
 import static com.codeborne.selenide.WebDriverRunner.supportsJavascript;
@@ -99,6 +102,35 @@ public class Selenide {
   public static void open(String relativeOrAbsoluteUrl, String domain, String login, String password) {
     navigator.open(relativeOrAbsoluteUrl, domain, login, password);
     mockModalDialogs();
+  }
+
+  /**
+   *
+   * The main starting point in your tests.
+   * <p>
+   * Open browser and pass authentication using build-in proxy.
+   * <p>
+   * A common authenticationType is "Basic". See Web HTTP reference for other types.
+   * <p>
+   * {@code Configuration.fileDownload == Configuration.FileDownloadMode.PROXY;} - is required configuration.
+   *
+   * @param relativeOrAbsoluteUrl
+   * @param authenticationType
+   * @param login
+   * @param password
+   *
+   * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Proxy-Authorization">Web HTTP reference</a>
+   * @see AuthenticationType
+   */
+  public static void open(final String relativeOrAbsoluteUrl, final AuthenticationType authenticationType,
+                          final String login, final String password) {
+    getAndCheckWebDriver();
+    final BrowserMobProxy proxy = getSelenideProxy().getProxy();
+    final Credentials credentials = new Credentials(login, password);
+    final String authorization = String.format("%s %s", authenticationType.getValue(), credentials.encode());
+    proxy.addHeader("Authorization", authorization);
+    proxy.addHeader("Proxy-Authorization", authorization);
+    navigator.open(relativeOrAbsoluteUrl);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/impl/Navigator.java
+++ b/src/main/java/com/codeborne/selenide/impl/Navigator.java
@@ -4,6 +4,7 @@ import com.codeborne.selenide.AuthenticationType;
 import com.codeborne.selenide.Credentials;
 import com.codeborne.selenide.logevents.SelenideLog;
 import com.codeborne.selenide.logevents.SelenideLogger;
+import com.codeborne.selenide.proxy.SelenideProxyServer;
 import io.netty.handler.codec.http.HttpHeaders;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
@@ -43,17 +44,18 @@ public class Navigator {
     navigateToAbsoluteUrl(url.toExternalForm());
   }
 
-  public void open(String relativeOrAbsoluteUrl, AuthenticationType authenticationType, String login, String password) {
+  public void open(String relativeOrAbsoluteUrl, AuthenticationType authenticationType, Credentials credentials) {
     getAndCheckWebDriver();
-    Credentials credentials = new Credentials(login, password);
     String authorization = String.format("%s %s", authenticationType.getValue(), credentials.encode());
-    getSelenideProxy().addRequestFilter("headers.request", (request, contents, messageInfo) -> {
-      final HttpHeaders headers = request.headers();
+    SelenideProxyServer selenideProxy = getSelenideProxy();
+    selenideProxy.addRequestFilter("headers.request", (request, contents, messageInfo) -> {
+      HttpHeaders headers = request.headers();
       headers.add("Authorization", authorization);
       headers.add("Proxy-Authorization", authorization);
       return null;
     });
     open(relativeOrAbsoluteUrl);
+    selenideProxy.removeRequestFilter("headers.request");
   }
 
   protected String absoluteUrl(String relativeUrl) {

--- a/src/main/java/com/codeborne/selenide/proxy/SelenideProxyServer.java
+++ b/src/main/java/com/codeborne/selenide/proxy/SelenideProxyServer.java
@@ -77,7 +77,6 @@ public class SelenideProxyServer {
     port = proxy.getPort();
   }
 
-
   /**
    * Add a custom request filter which allows to track/modify all requests from browser to server
    *
@@ -85,12 +84,28 @@ public class SelenideProxyServer {
    * @param requestFilter the filter
    */
   public void addRequestFilter(String name, RequestFilter requestFilter) {
-    if (requestFilters.containsKey(name)) {
+    if (isRequestFilterAdded(name)) {
       throw new IllegalArgumentException("Duplicate request filter: " + name);
     }
-
     proxy.addRequestFilter(requestFilter);
     requestFilters.put(name, requestFilter);
+  }
+
+  private boolean isRequestFilterAdded(String name) {
+    return requestFilters.containsKey(name);
+  }
+
+  /**
+   * Remove a custom request filter by name
+   *
+   * @param name unique name of filter
+   */
+  public void removeRequestFilter(String name) {
+    if (isRequestFilterAdded(name)) {
+      requestFilters.remove(name);
+    } else {
+      throw new IllegalArgumentException("Missing request filter: " + name);
+    }
   }
 
   /**

--- a/src/test/java/integration/BasicAuthTest.java
+++ b/src/test/java/integration/BasicAuthTest.java
@@ -3,6 +3,7 @@ package integration;
 import com.codeborne.selenide.AuthenticationType;
 import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.Configuration.FileDownloadMode;
+import com.codeborne.selenide.Credentials;
 import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.Condition.text;
@@ -17,9 +18,17 @@ class BasicAuthTest extends IntegrationTest {
   }
 
   @Test
-  void canAuthUsingProxy() {
+  void canAuthUsingProxyWithLoginAndPassword() {
     Configuration.fileDownload = FileDownloadMode.PROXY;
     open("/basic-auth/hello", AuthenticationType.BASIC, "scott", "tiger");
+    $("body").shouldHave(text("Hello, scott:tiger!"));
+  }
+
+  @Test
+  void canAuthUsingProxyWithCredentials() {
+    Configuration.fileDownload = FileDownloadMode.PROXY;
+    Credentials credentials = new Credentials("scott", "tiger");
+    open("/basic-auth/hello", AuthenticationType.BASIC, credentials);
     $("body").shouldHave(text("Hello, scott:tiger!"));
   }
 }

--- a/src/test/java/integration/BasicAuthTest.java
+++ b/src/test/java/integration/BasicAuthTest.java
@@ -1,5 +1,8 @@
 package integration;
 
+import com.codeborne.selenide.AuthenticationType;
+import com.codeborne.selenide.Configuration;
+import com.codeborne.selenide.Configuration.FileDownloadMode;
 import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.Condition.text;
@@ -10,6 +13,13 @@ class BasicAuthTest extends IntegrationTest {
   @Test
   void canPassBasicAuth() {
     open("/basic-auth/hello", "", "scott", "tiger");
+    $("body").shouldHave(text("Hello, scott:tiger!"));
+  }
+
+  @Test
+  void canAuthUsingProxy() {
+    Configuration.fileDownload = FileDownloadMode.PROXY;
+    open("/basic-auth/hello", AuthenticationType.BASIC, "scott", "tiger");
     $("body").shouldHave(text("Hello, scott:tiger!"));
   }
 }


### PR DESCRIPTION
## Proposed changes
Fix #784 issue. Enable BasicAuth through Selenide proxy server

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)