### PR TITLE
Fix FirefoxDriverFactory overwrites Firefox profile provided by Configuration issue

### DIFF
--- a/src/main/java/com/codeborne/selenide/Configuration.java
+++ b/src/main/java/com/codeborne/selenide/Configuration.java
@@ -149,9 +149,9 @@ public class Configuration {
    * Browser capabilities.
    * Warning: this capabilities will override capabilities were set by system properties.
    * <br>
-   * Default value: null
+   * Default value: DesiredCapabilities::new
    */
-  public static DesiredCapabilities browserCapabilities;
+  public static DesiredCapabilities browserCapabilities = new DesiredCapabilities();
   /**
    * Should webdriver wait until page is completely loaded.
    * Possible values: "none", "normal" and "eager".

--- a/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
@@ -1,6 +1,7 @@
 package com.codeborne.selenide.webdriver;
 
 import com.codeborne.selenide.WebDriverRunner;
+import java.util.Optional;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
@@ -56,7 +57,8 @@ class FirefoxDriverFactory extends AbstractDriverFactory {
 
   private FirefoxOptions transferFirefoxProfileFromSystemProperties(FirefoxOptions currentFirefoxOptions) {
     String prefix = "firefoxprofile.";
-    FirefoxProfile profile = new FirefoxProfile();
+    FirefoxProfile profile = Optional.ofNullable(currentFirefoxOptions.getProfile())
+      .orElseGet(FirefoxProfile::new);
     for (String key : System.getProperties().stringPropertyNames()) {
       if (key.startsWith(prefix)) {
         String capability = key.substring(prefix.length());

--- a/src/test/java/com/codeborne/selenide/webdriver/FirefoxDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/FirefoxDriverFactoryTest.java
@@ -11,6 +11,7 @@ import org.openqa.selenium.firefox.FirefoxProfile;
 
 import java.util.List;
 import java.util.Map;
+import org.openqa.selenium.remote.DesiredCapabilities;
 
 import static com.codeborne.selenide.webdriver.SeleniumCapabilitiesHelper.getBrowserLaunchArgs;
 import static org.mockito.Mockito.mock;
@@ -25,6 +26,7 @@ class FirefoxDriverFactoryTest implements WithAssertions {
     System.clearProperty("firefoxprofile.some.cap");
     Configuration.browserBinary = "";
     Configuration.headless = false;
+    Configuration.browserCapabilities = new DesiredCapabilities();
   }
 
   @Test
@@ -44,6 +46,20 @@ class FirefoxDriverFactoryTest implements WithAssertions {
   void transfersIntegerCapabilitiesFromSystemPropsToDriver() {
     System.setProperty("capabilities.some.cap", "25");
     assertThat(driverFactory.createCommonCapabilities(proxy).getCapability("some.cap")).isEqualTo(25);
+  }
+
+  @Test
+  void keepConfigurationFirefoxProfileWhenTransferPreferencesFromSystemPropsToDriver() {
+    FirefoxProfile configurationProfile = new FirefoxProfile();
+    configurationProfile.setPreference("some.conf.cap", 42);
+    FirefoxOptions firefoxOptions = new FirefoxOptions().setProfile(configurationProfile);
+    Configuration.browserCapabilities = new DesiredCapabilities(firefoxOptions);
+    System.setProperty("firefoxprofile.some.cap", "25");
+
+    FirefoxProfile profile = driverFactory.createFirefoxOptions(proxy).getProfile();
+
+    assertThat(profile.getIntegerPreference("some.cap", 0)).isEqualTo(25);
+    assertThat(profile.getIntegerPreference("some.conf.cap", 0)).isEqualTo(42);
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/webdriver/TransferBrowserCapabilitiesFromConfigurationTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/TransferBrowserCapabilitiesFromConfigurationTest.java
@@ -17,16 +17,14 @@ class TransferBrowserCapabilitiesFromConfigurationTest implements WithAssertions
 
   @AfterEach
   void clearConfiguration() {
-    Configuration.browserCapabilities = null;
+    Configuration.browserCapabilities = new DesiredCapabilities();
     System.clearProperty(SOME_CAP);
   }
 
   @BeforeEach
   void createFactory() {
     driverFactory = new ChromeDriverFactory();
-    DesiredCapabilities configurationCapabilities = new DesiredCapabilities();
-    configurationCapabilities.setCapability(SOME_CAP, "SOME_VALUE_FROM_CONFIGURATION");
-    Configuration.browserCapabilities = configurationCapabilities;
+    Configuration.browserCapabilities.setCapability(SOME_CAP, "SOME_VALUE_FROM_CONFIGURATION");
   }
 
   @Test


### PR DESCRIPTION
Change default value for Configuration.browserCapabilities to not null
Fix FirefoxDriverFactory overwrites Firefox profile provided by Configuration issue


## Checklist
- [ ] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)