### PR TITLE
Workaround for webdrivermanager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * #806 Remove deprecated APIs   --  thanks to @rosolko for PR #812 
 * bugfix: method Selenide.download() should not fail if there is no opened browser yet
 * #825 Upgrade to WebDriverManager 3.0.0 (again)
+* #825 Add workaround for WebDriverManager issue when it calls github too often and gets 403 error
 
 Technical changes (probably should not affect end users):
 * Move constants IE, FIREFOX etc from class `WebDriverRunner` to its parent class `Browsers`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * #810 set browser size to 1366x768 by default   --  thanks to @rosolko for PR #812 
 * #806 Remove deprecated APIs   --  thanks to @rosolko for PR #812 
 * bugfix: method Selenide.download() should not fail if there is no opened browser yet
+* #825 Upgrade to WebDriverManager 3.0.0 (again)
 
 Technical changes (probably should not affect end users):
 * Move constants IE, FIREFOX etc from class `WebDriverRunner` to its parent class `Browsers`

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
 group = 'com.codeborne'
 archivesBaseName = 'selenide'
-version = '5.0.0-rc.1'
+version = '5.0.0-SNAPSHOT'
 
 ext {
   encoding = StandardCharsets.UTF_8.name()

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,7 +12,7 @@ ext {
 
 dependencies {
   api("org.seleniumhq.selenium:selenium-java:$seleniumVersion")
-  api('io.github.bonigarcia:webdrivermanager:2.2.5')
+  api('io.github.bonigarcia:webdrivermanager:3.0.0')
 
   implementation('net.lightbody.bmp:browsermob-core:2.1.5')
 

--- a/src/main/java/com/codeborne/selenide/webdriver/WebDriverBinaryManager.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/WebDriverBinaryManager.java
@@ -5,12 +5,16 @@ import io.github.bonigarcia.wdm.WebDriverManager;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Date;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
 
 import static io.github.bonigarcia.wdm.WebDriverManager.config;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class WebDriverBinaryManager {
+  private static final Logger log = Logger.getLogger(WebDriverBinaryManager.class.getName());
+
   public void setupBinaryPath(Browser browser) {
     if (browser.isChrome()) setupChrome();
     if (browser.isEdge()) setupEdge();
@@ -58,19 +62,34 @@ public class WebDriverBinaryManager {
 
   private void cacheMeIfYouCan(String systemPropertyName, Runnable webdriverSetup) {
     if (webdriverIsAlreadyInitialized(systemPropertyName)) {
+      log.info("Skip: webdriver is already initialized: " + System.getProperty(systemPropertyName));
       return;
     }
 
     File lastCheckIndicator = new File(config().getTargetPath(), lastModifiedFileName(systemPropertyName));
     boolean canUseCachedWebdriver = lastCheckIndicator.exists() && hasRecentlyCheckedForUpdates(lastCheckIndicator);
+    log.info("lastCheckIndicator=" + lastCheckIndicator.getAbsolutePath() +
+      ", exists=" + lastCheckIndicator.exists() + ", lastModified=" + new Date(lastCheckIndicator.lastModified()) +
+      ", now=" + new Date() + ", diff: " + (System.currentTimeMillis() - lastCheckIndicator.lastModified()) + " ms.");
+
     if (canUseCachedWebdriver) {
+      log.info("Can use cache");
       config().setForceCache(true);
+    }
+    else {
+      log.info("Cannot use cache");
     }
 
     webdriverSetup.run();
 
     if (!canUseCachedWebdriver) {
+      long ts = System.currentTimeMillis();
+      log.info("Mark as recently checked: " + lastCheckIndicator.getAbsolutePath() + ", ts=" + ts + ", now=" + new Date(ts));
       markAsRecentlyChecked(lastCheckIndicator);
+    }
+    else {
+      long ts = System.currentTimeMillis();
+      log.info("Not marking as recently checked: " + lastCheckIndicator.getAbsolutePath() + ", ts=" + ts + ", now=" + new Date(ts));
     }
   }
 


### PR DESCRIPTION
## Proposed changes
Let's store in a file `~/.m2/repository/webdriver/webdriver.gecko.driver.mac64.timestamp` the timestamp when WDM checked for updates last time.

It will allows us to avoid WDM calling github too often thus getting "403 error" too often.

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)